### PR TITLE
[upd] Updated tsid with the latest version of pinocchio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ ENDIF(EIGEN_NO_AUTOMATIC_RESIZING)
 # --- DEPENDANCIES -----------------------------------
 # ----------------------------------------------------
 ADD_REQUIRED_DEPENDENCY("eigen3 >= 3.2.0") # Eigen::Ref appeared from 3.2.0
-ADD_REQUIRED_DEPENDENCY("pinocchio >= 1.2.0")
+ADD_REQUIRED_DEPENDENCY("pinocchio >= 1.2.6")
 
 SET(BOOST_COMPONENTS unit_test_framework)
 

--- a/src/robots/robot-wrapper.cpp
+++ b/src/robots/robot-wrapper.cpp
@@ -170,14 +170,14 @@ namespace tsid
                                      const Model::JointIndex index,
                                      Data::Matrix6x & J) const
     {
-      return se3::getJacobian<false>(m_model, data, index, J);
+      return se3::getJacobian<se3::WORLD>(m_model, data, index, J);
     }
     
     void RobotWrapper::jacobianLocal(const Data & data,
                                      const Model::JointIndex index,
                                      Data::Matrix6x & J) const
     {
-      return se3::getJacobian<true>(m_model, data, index, J);
+      return se3::getJacobian<se3::LOCAL>(m_model, data, index, J);
     }
     
     SE3 RobotWrapper::framePosition(const Data & data,
@@ -249,14 +249,15 @@ namespace tsid
                                           const Model::FrameIndex index,
                                           Data::Matrix6x & J) const
     {
-      return se3::getFrameJacobian<false>(m_model, data, index, J);
+      return se3::getFrameJacobian(m_model, data, index, J);
     }
     
     void RobotWrapper::frameJacobianLocal(const Data & data,
                                           const Model::FrameIndex index,
                                           Data::Matrix6x & J) const
     {
-      return se3::getFrameJacobian<true>(m_model, data, index, J);
+      //se3::framesForwardKinematics(*m_model, data);//TODO ask Andrea if we need this
+      return se3::getFrameJacobian(m_model, data, index, J);
     }
     
     //    const Vector3 & com(Data & data,const Vector & q,

--- a/src/robots/robot-wrapper.cpp
+++ b/src/robots/robot-wrapper.cpp
@@ -249,7 +249,7 @@ namespace tsid
                                           const Model::FrameIndex index,
                                           Data::Matrix6x & J) const
     {
-      return se3::getJacobian<se3::WORLD>(m_model, data, index, J);
+      return se3::getJacobian<se3::WORLD>(m_model, data, m_model.frames[index].parent, J);
     }
     
     void RobotWrapper::frameJacobianLocal(const Data & data,

--- a/src/robots/robot-wrapper.cpp
+++ b/src/robots/robot-wrapper.cpp
@@ -249,14 +249,13 @@ namespace tsid
                                           const Model::FrameIndex index,
                                           Data::Matrix6x & J) const
     {
-      return se3::getFrameJacobian(m_model, data, index, J);
+      return se3::getJacobian<se3::WORLD>(m_model, data, index, J);
     }
     
     void RobotWrapper::frameJacobianLocal(const Data & data,
                                           const Model::FrameIndex index,
                                           Data::Matrix6x & J) const
     {
-      //se3::framesForwardKinematics(*m_model, data);//TODO ask Andrea if we need this
       return se3::getFrameJacobian(m_model, data, index, J);
     }
     


### PR DESCRIPTION
This pull request uses the latest version of pinocchio. Reviewing the code with @flforget we think that we need to include the following line: "se3::framesForwardKinematics(*m_model, data) inside frameJacobianLocal() function". @andreadelprete could you confirm us that this is required?