### PR TITLE
Compatibility with catkinized Pinocchio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,12 @@ ENDIF(EIGEN_NO_AUTOMATIC_RESIZING)
 # --- DEPENDENCIES -----------------------------------
 # ----------------------------------------------------
 ADD_REQUIRED_DEPENDENCY("eigen3 >= 3.2.0") # Eigen::Ref appeared from 3.2.0
+
+# Fail-safe support for catkin-ized pinocchio:
+#  - If catkin-based pinocchio is installed it runs the CFG_EXTRAS to set up the Pinocchio preprocessor directives
+#  - If it isn't, nothing happens and the subsequent pkg-config check takes care of everything.
+find_package(catkin QUIET COMPONENTS pinocchio)
+
 ADD_REQUIRED_DEPENDENCY("pinocchio >= 1.3.0")
 
 SET(BOOST_REQUIERED_COMPONENTS filesystem system)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ IF(EIGEN_NO_AUTOMATIC_RESIZING)
 ENDIF(EIGEN_NO_AUTOMATIC_RESIZING)
 
 # ----------------------------------------------------
-# --- DEPENDANCIES -----------------------------------
+# --- DEPENDENCIES -----------------------------------
 # ----------------------------------------------------
 ADD_REQUIRED_DEPENDENCY("eigen3 >= 3.2.0") # Eigen::Ref appeared from 3.2.0
 ADD_REQUIRED_DEPENDENCY("pinocchio >= 1.3.0")


### PR DESCRIPTION
We are currently working on packaging Pinocchio v2 for catkin, and then releasing it to the ROS buildfarm (including the Python bindings via eigenpy, which will also get released as binaries on ROS). One defect due to limitations in catkin is that the preprocessor directives (for urdfdom, lua, etc.) are not included in the pkg-config generated by catkin - this works for CMake though.

This PR introduces a fail-safe support for both existing Pinocchio and catkinized Pinocchio. It searches _quietly_ for catkin Pinocchio which sets up the `add_definitions`. If not found, the normal procedure is followed.