### PR TITLE
[pinocchio-v2.1] Apply pinocchio v2.1.0 API changes.

### DIFF
--- a/include/tsid/contacts/contact-6d.hpp
+++ b/include/tsid/contacts/contact-6d.hpp
@@ -43,7 +43,7 @@ namespace tsid
       typedef tasks::TaskSE3Equality TaskSE3Equality;
       typedef math::ConstraintInequality ConstraintInequality;
       typedef math::ConstraintEquality ConstraintEquality;
-      typedef se3::SE3 SE3;
+      typedef pinocchio::SE3 SE3;
 
       Contact6d(const std::string & name,
                 RobotWrapper & robot,

--- a/include/tsid/contacts/contact-base.hpp
+++ b/include/tsid/contacts/contact-base.hpp
@@ -42,7 +42,7 @@ namespace tsid
       typedef math::ConstRefVector ConstRefVector;
       typedef math::Matrix Matrix;
       typedef tasks::TaskMotion TaskMotion;
-      typedef se3::Data Data;
+      typedef pinocchio::Data Data;
       typedef robots::RobotWrapper RobotWrapper;
 
       ContactBase(const std::string & name,

--- a/include/tsid/formulations/inverse-dynamics-formulation-acc-force.hpp
+++ b/include/tsid/formulations/inverse-dynamics-formulation-acc-force.hpp
@@ -72,7 +72,7 @@ namespace tsid
   public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-    typedef se3::Data Data;
+    typedef pinocchio::Data Data;
     typedef math::Vector Vector;
     typedef math::Matrix Matrix;
     typedef math::ConstRefVector ConstRefVector;

--- a/include/tsid/formulations/inverse-dynamics-formulation-base.hpp
+++ b/include/tsid/formulations/inverse-dynamics-formulation-base.hpp
@@ -40,7 +40,7 @@ namespace tsid
   public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-    typedef se3::Data Data;
+    typedef pinocchio::Data Data;
     typedef math::Vector Vector;
     typedef math::RefVector RefVector;
     typedef math::ConstRefVector ConstRefVector;

--- a/include/tsid/math/utils.hpp
+++ b/include/tsid/math/utils.hpp
@@ -81,18 +81,18 @@ namespace tsid
     /**
      * Convert the input SE3 object to a 7D vector of floats [X,Y,Z,Q1,Q2,Q3,Q4].
      */
-    void SE3ToXYZQUAT(const se3::SE3 & M, RefVector xyzQuat);
+    void SE3ToXYZQUAT(const pinocchio::SE3 & M, RefVector xyzQuat);
 
     /**
      * Convert the input SE3 object to a 12D vector of floats [X,Y,Z,R11,R12,R13,R14,...].
      */
-    void SE3ToVector(const se3::SE3 & M, RefVector vec);
+    void SE3ToVector(const pinocchio::SE3 & M, RefVector vec);
 
-    void vectorToSE3(RefVector vec, se3::SE3 & M);
+    void vectorToSE3(RefVector vec, pinocchio::SE3 & M);
 
-    void errorInSE3 (const se3::SE3 & M,
-                     const se3::SE3 & Mdes,
-                     se3::Motion & error);
+    void errorInSE3 (const pinocchio::SE3 & M,
+                     const pinocchio::SE3 & Mdes,
+                     pinocchio::Motion & error);
 
     void solveWithDampingFromSvd(Eigen::JacobiSVD<Eigen::MatrixXd> & svd,
                              ConstRefVector b,

--- a/include/tsid/robots/robot-wrapper.hpp
+++ b/include/tsid/robots/robot-wrapper.hpp
@@ -28,6 +28,7 @@
 #include <string>
 #include <vector>
 
+
 namespace tsid
 {
   namespace robots
@@ -41,11 +42,11 @@ namespace tsid
       EIGEN_MAKE_ALIGNED_OPERATOR_NEW
       
       typedef math::Scalar Scalar;
-      typedef se3::Model Model;
-      typedef se3::Data Data;
-      typedef se3::Motion Motion;
-      typedef se3::Frame Frame;
-      typedef se3::SE3 SE3;
+      typedef pinocchio::Model Model;
+      typedef pinocchio::Data Data;
+      typedef pinocchio::Motion Motion;
+      typedef pinocchio::Frame Frame;
+      typedef pinocchio::SE3 SE3;
       typedef math::Vector  Vector;
       typedef math::Vector3 Vector3;
       typedef math::Vector6 Vector6;
@@ -61,7 +62,7 @@ namespace tsid
       
       RobotWrapper(const std::string & filename,
                    const std::vector<std::string> & package_dirs,
-                   const se3::JointModelVariant & rootJoint,
+                   const pinocchio::JointModelVariant & rootJoint,
                    bool verbose=false);
       
       virtual int nq() const;

--- a/include/tsid/solvers/fwd.hpp
+++ b/include/tsid/solvers/fwd.hpp
@@ -81,10 +81,10 @@ namespace tsid
     { return aligned_pair<T1,T2>(t1,t2); }
     
     
-    typedef se3::container::aligned_vector< aligned_pair<double, math::ConstraintBase*> > ConstraintLevel;
-    typedef se3::container::aligned_vector< aligned_pair<double, const math::ConstraintBase*> > ConstConstraintLevel;
-    typedef se3::container::aligned_vector<ConstraintLevel> HQPData;
-    typedef se3::container::aligned_vector<ConstConstraintLevel> ConstHQPData;
+    typedef pinocchio::container::aligned_vector< aligned_pair<double, math::ConstraintBase*> > ConstraintLevel;
+    typedef pinocchio::container::aligned_vector< aligned_pair<double, const math::ConstraintBase*> > ConstConstraintLevel;
+    typedef pinocchio::container::aligned_vector<ConstraintLevel> HQPData;
+    typedef pinocchio::container::aligned_vector<ConstConstraintLevel> ConstHQPData;
     
     
   }

--- a/include/tsid/tasks/task-base.hpp
+++ b/include/tsid/tasks/task-base.hpp
@@ -40,7 +40,7 @@ namespace tsid
       
       typedef math::ConstraintBase ConstraintBase;
       typedef math::ConstRefVector ConstRefVector;
-      typedef se3::Data Data;
+      typedef pinocchio::Data Data;
       typedef robots::RobotWrapper RobotWrapper;
 
       TaskBase(const std::string & name,

--- a/include/tsid/tasks/task-joint-posture.hpp
+++ b/include/tsid/tasks/task-joint-posture.hpp
@@ -37,7 +37,7 @@ namespace tsid
       typedef math::Vector Vector;
       typedef math::VectorXi VectorXi;
       typedef math::ConstraintEquality ConstraintEquality;
-      typedef se3::Data Data;
+      typedef pinocchio::Data Data;
 
       TaskJointPosture(const std::string & name,
                       RobotWrapper & robot);

--- a/include/tsid/tasks/task-se3-equality.hpp
+++ b/include/tsid/tasks/task-se3-equality.hpp
@@ -39,10 +39,10 @@ namespace tsid
       typedef trajectories::TrajectorySample TrajectorySample;
       typedef math::Vector Vector;
       typedef math::ConstraintEquality ConstraintEquality;
-      typedef se3::Data Data;
-      typedef se3::Data::Matrix6x Matrix6x;
-      typedef se3::Motion Motion;
-      typedef se3::SE3 SE3;
+      typedef pinocchio::Data Data;
+      typedef pinocchio::Data::Matrix6x Matrix6x;
+      typedef pinocchio::Motion Motion;
+      typedef pinocchio::SE3 SE3;
 
       TaskSE3Equality(const std::string & name,
                       RobotWrapper & robot,

--- a/include/tsid/trajectories/trajectory-se3.hpp
+++ b/include/tsid/trajectories/trajectory-se3.hpp
@@ -32,7 +32,7 @@ namespace tsid
     public:
       EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-      typedef se3::SE3 SE3;
+      typedef pinocchio::SE3 SE3;
 
       TrajectorySE3Constant(const std::string & name);
 

--- a/src/contacts/contact-6d.cpp
+++ b/src/contacts/contact-6d.cpp
@@ -134,7 +134,7 @@ void Contact6d:: updateForceGeneratorMatrix()
   for(int i=0; i<4; i++)
   {
     m_forceGenMat.block<3,3>(0, i*3).setIdentity();
-    m_forceGenMat.block<3,3>(3, i*3) = se3::skew(m_contactPoints.col(i));
+    m_forceGenMat.block<3,3>(3, i*3) = pinocchio::skew(m_contactPoints.col(i));
   }
 }
 

--- a/src/formulations/inverse-dynamics-formulation-acc-force.cpp
+++ b/src/formulations/inverse-dynamics-formulation-acc-force.cpp
@@ -25,7 +25,7 @@ using namespace tasks;
 using namespace contacts;
 using namespace solvers;
 
-typedef se3::Data Data;
+typedef pinocchio::Data Data;
 
 TaskLevel::TaskLevel(tasks::TaskBase & task,
                      unsigned int priority):

--- a/src/math/utils.cpp
+++ b/src/math/utils.cpp
@@ -22,14 +22,14 @@ namespace tsid
   namespace math
   {
     
-    void SE3ToXYZQUAT(const se3::SE3 & M, RefVector xyzQuat)
+    void SE3ToXYZQUAT(const pinocchio::SE3 & M, RefVector xyzQuat)
     {
       assert(xyzQuat.size()==7);
       xyzQuat.head<3>() = M.translation();
       xyzQuat.tail<4>() = Eigen::Quaterniond(M.rotation()).coeffs();
     }
 
-    void SE3ToVector(const se3::SE3 & M, RefVector vec)
+    void SE3ToVector(const pinocchio::SE3 & M, RefVector vec)
     {
       assert(vec.size()==12);
       vec.head<3>() = M.translation();
@@ -37,7 +37,7 @@ namespace tsid
       vec.tail<9>() = Eigen::Map<const Vector9>(&M.rotation()(0), 9);
     }
 
-    void vectorToSE3(RefVector vec, se3::SE3 & M)
+    void vectorToSE3(RefVector vec, pinocchio::SE3 & M)
     {
       assert(vec.size()==12);
       M.translation( vec.head<3>() );
@@ -45,11 +45,11 @@ namespace tsid
       M.rotation( Eigen::Map<const Matrix3>(&vec(3), 3, 3) );
     }
     
-    void errorInSE3 (const se3::SE3 & M,
-                     const se3::SE3 & Mdes,
-                     se3::Motion & error)
+    void errorInSE3 (const pinocchio::SE3 & M,
+                     const pinocchio::SE3 & Mdes,
+                     pinocchio::Motion & error)
     {
-      error = se3::log6(Mdes.inverse() * M);
+      error = pinocchio::log6(Mdes.inverse() * M);
     }
     
     void solveWithDampingFromSvd(Eigen::JacobiSVD<Eigen::MatrixXd> & svd,

--- a/src/robots/robot-wrapper.cpp
+++ b/src/robots/robot-wrapper.cpp
@@ -24,7 +24,7 @@
 #include <pinocchio/algorithm/jacobian.hpp>
 #include <pinocchio/algorithm/frames.hpp>
 
-using namespace se3;
+using namespace pinocchio;
 using namespace tsid::math;
 
 namespace tsid
@@ -37,7 +37,7 @@ namespace tsid
                                bool verbose)
     : m_verbose(verbose)
     {
-      se3::urdf::buildModel(filename, m_model, m_verbose);
+      pinocchio::urdf::buildModel(filename, m_model, m_verbose);
       m_model_filename = filename;
       m_rotor_inertias.setZero(m_model.nv);
       m_gear_ratios.setZero(m_model.nv);
@@ -47,11 +47,11 @@ namespace tsid
     
     RobotWrapper::RobotWrapper(const std::string & filename,
                                const std::vector<std::string> & ,
-                               const se3::JointModelVariant & rootJoint,
+                               const pinocchio::JointModelVariant & rootJoint,
                                bool verbose)
     : m_verbose(verbose)
     {
-      se3::urdf::buildModel(filename, rootJoint, m_model, m_verbose);
+      pinocchio::urdf::buildModel(filename, rootJoint, m_model, m_verbose);
       m_model_filename = filename;
       m_rotor_inertias.setZero(m_model.nv-6);
       m_gear_ratios.setZero(m_model.nv-6);
@@ -67,13 +67,14 @@ namespace tsid
     
     void RobotWrapper::computeAllTerms(Data & data, const Vector & q, const Vector & v) const
     {
-      se3::computeAllTerms(m_model, data, q, v);
+      pinocchio::computeAllTerms(m_model, data, q, v);
       data.M.triangularView<Eigen::StrictlyLower>()
             = data.M.transpose().triangularView<Eigen::StrictlyLower>();
       // computeAllTerms does not compute the com acceleration, so we need to call centerOfMass
-      se3::centerOfMass<true,true,true>(m_model, data, false);
-      se3::updateFramePlacements(m_model, data);
-      se3::centerOfMass(m_model, data, q, v, Eigen::VectorXd::Zero(nv()));
+      // Check this line, calling with zero acceleration at the last phase compute the CoM acceleration.
+      //      pinocchio::centerOfMass(m_model, data, q,v,false);
+      pinocchio::framesForwardKinematics(m_model, data);
+      pinocchio::centerOfMass(m_model, data, q, v, Eigen::VectorXd::Zero(nv()));
     }
     
     const Vector & RobotWrapper::rotor_inertias() const
@@ -170,14 +171,22 @@ namespace tsid
                                      const Model::JointIndex index,
                                      Data::Matrix6x & J) const
     {
+<<<<<<< 7036c61c0ac04313b92b5f31544ab4986d80bba0
       return se3::getJointJacobian<se3::WORLD>(m_model, data, index, J);
+=======
+      return pinocchio::getFrameJacobian(m_model, data, index,pinocchio::WORLD,J);
+>>>>>>> [pinocchio-v2.1] Apply pinocchio v2.1.0 API changes.
     }
     
     void RobotWrapper::jacobianLocal(const Data & data,
                                      const Model::JointIndex index,
                                      Data::Matrix6x & J) const
     {
+<<<<<<< 7036c61c0ac04313b92b5f31544ab4986d80bba0
       return se3::getJointJacobian<se3::LOCAL>(m_model, data, index, J);
+=======
+      return pinocchio::getFrameJacobian(m_model, data, index,pinocchio::LOCAL, J);
+>>>>>>> [pinocchio-v2.1] Apply pinocchio v2.1.0 API changes.
     }
     
     SE3 RobotWrapper::framePosition(const Data & data,
@@ -249,27 +258,35 @@ namespace tsid
                                           const Model::FrameIndex index,
                                           Data::Matrix6x & J) const
     {
+<<<<<<< 7036c61c0ac04313b92b5f31544ab4986d80bba0
       return se3::getJointJacobian<se3::WORLD>(m_model, data, m_model.frames[index].parent, J);
+=======
+      return pinocchio::getFrameJacobian(m_model, data, m_model.frames[index].parent,pinocchio::WORLD, J);
+>>>>>>> [pinocchio-v2.1] Apply pinocchio v2.1.0 API changes.
     }
     
     void RobotWrapper::frameJacobianLocal(const Data & data,
                                           const Model::FrameIndex index,
                                           Data::Matrix6x & J) const
     {
+<<<<<<< 7036c61c0ac04313b92b5f31544ab4986d80bba0
       return se3::getFrameJacobian<se3::LOCAL>(m_model, data, index, J);
+=======
+      return pinocchio::getFrameJacobian(m_model, data, index, pinocchio::LOCAL,J);
+>>>>>>> [pinocchio-v2.1] Apply pinocchio v2.1.0 API changes.
     }
     
     //    const Vector3 & com(Data & data,const Vector & q,
     //                        const bool computeSubtreeComs = true,
     //                        const bool updateKinematics = true)
     //    {
-    //      return se3::centerOfMass(m_model, data, q, computeSubtreeComs, updateKinematics);
+    //      return pinocchio::centerOfMass(m_model, data, q, computeSubtreeComs, updateKinematics);
     //    }
     //    const Vector3 & com(Data & data, const Vector & q, const Vector & v,
     //                 const bool computeSubtreeComs = true,
     //                 const bool updateKinematics = true)
     //    {
-    //      return se3::centerOfMass(m_model, data, q, v, computeSubtreeComs, updateKinematics);
+    //      return pinocchio::centerOfMass(m_model, data, q, v, computeSubtreeComs, updateKinematics);
     //    }
     
   } // namespace robots

--- a/src/tasks/task-com-equality.cpp
+++ b/src/tasks/task-com-equality.cpp
@@ -24,7 +24,7 @@ namespace tsid
   {
     using namespace math;
     using namespace trajectories;
-    using namespace se3;
+    using namespace pinocchio;
 
     TaskComEquality::TaskComEquality(const std::string & name,
                                      RobotWrapper & robot):

--- a/src/tasks/task-joint-posture.cpp
+++ b/src/tasks/task-joint-posture.cpp
@@ -24,7 +24,7 @@ namespace tsid
   {
     using namespace math;
     using namespace trajectories;
-    using namespace se3;
+    using namespace pinocchio;
 
     TaskJointPosture::TaskJointPosture(const std::string & name,
                                      RobotWrapper & robot):

--- a/src/tasks/task-se3-equality.cpp
+++ b/src/tasks/task-se3-equality.cpp
@@ -25,7 +25,7 @@ namespace tsid
   {
     using namespace math;
     using namespace trajectories;
-    using namespace se3;
+    using namespace pinocchio;
 
     TaskSE3Equality::TaskSE3Equality(const std::string & name,
                                      RobotWrapper & robot,

--- a/unittest/contacts.cpp
+++ b/unittest/contacts.cpp
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE ( test_contact_6d )
   string urdfFileName = package_dirs[0] + "/urdf/romeo.urdf";
   RobotWrapper robot(urdfFileName,
                      package_dirs,
-                     se3::JointModelFreeFlyer(),
+                     pinocchio::JointModelFreeFlyer(),
                      false);
 
   BOOST_REQUIRE(robot.model().existFrame(frameName));
@@ -77,12 +77,12 @@ BOOST_AUTO_TEST_CASE ( test_contact_6d )
   BOOST_CHECK(contact.Kp().isApprox(Kp));
   BOOST_CHECK(contact.Kd().isApprox(Kd));
 
-  Vector q = robot.model().neutralConfiguration;
+  Vector q = neutral(robot.model());
   Vector v = Vector::Zero(robot.nv());
-  se3::Data data(robot.model());
+  pinocchio::Data data(robot.model());
   robot.computeAllTerms(data, q, v);
 
-  se3::SE3 H_ref = robot.position(data, robot.model().getJointId(frameName));
+  pinocchio::SE3 H_ref = robot.position(data, robot.model().getJointId(frameName));
   contact.setReference(H_ref);
 
   double t = 0.0;

--- a/unittest/robot-wrapper.cpp
+++ b/unittest/robot-wrapper.cpp
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE ( test_robot_wrapper )
 {
 
   using namespace std;
-  using namespace se3;
+  using namespace pinocchio;
   
   const string romeo_model_path = TSID_SOURCE_DIR"/models/romeo";
 
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE ( test_robot_wrapper )
   
   RobotWrapper robot(urdfFileName,
                      package_dirs,
-                     se3::JointModelFreeFlyer(),
+                     pinocchio::JointModelFreeFlyer(),
                      false);
   
   const Model & model = robot.model();
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_CASE ( test_robot_wrapper )
   ub.head<3>().fill(10.);
   ub.segment<4>(3).fill(1.);
   
-  Vector q = se3::randomConfiguration(model,lb,ub);
+  Vector q = pinocchio::randomConfiguration(model,lb,ub);
   Vector v = Vector::Ones(robot.nv());
   Data data(robot.model());
   robot.computeAllTerms(data, q, v);

--- a/unittest/tasks.cpp
+++ b/unittest/tasks.cpp
@@ -63,7 +63,7 @@ BOOST_AUTO_TEST_CASE ( test_task_se3_equality )
   string urdfFileName = package_dirs[0] + "/urdf/romeo.urdf";
   RobotWrapper robot(urdfFileName,
                      package_dirs,
-                     se3::JointModelFreeFlyer(),
+                     pinocchio::JointModelFreeFlyer(),
                      false);
 
   TaskSE3Equality task("task-se3", robot, "RWristPitch");
@@ -75,7 +75,7 @@ BOOST_AUTO_TEST_CASE ( test_task_se3_equality )
   BOOST_CHECK(task.Kp().isApprox(Kp));
   BOOST_CHECK(task.Kd().isApprox(Kd));
 
-  se3::SE3 M_ref = se3::SE3::Random();
+  pinocchio::SE3 M_ref = pinocchio::SE3::Random();
   TrajectoryBase *traj = new TrajectorySE3Constant("traj_SE3", M_ref);
   TrajectorySample sample;
 
@@ -83,9 +83,9 @@ BOOST_AUTO_TEST_CASE ( test_task_se3_equality )
   const double dt = 0.001;
   MatrixXd Jpinv(robot.nv(), 6);
   double error, error_past=1e100;
-  VectorXd q = robot.model().neutralConfiguration;
+  VectorXd q = neutral(robot.model());
   VectorXd v = VectorXd::Zero(robot.nv());
-  se3::Data data(robot.model());
+  pinocchio::Data data(robot.model());
   for(int i=0; i<max_it; i++)
   {
     robot.computeAllTerms(data, q, v);
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE ( test_task_se3_equality )
     REQUIRE_FINITE(dv.transpose());
 
     v += dt*dv;
-    q = se3::integrate(robot.model(), q, dt*v);
+    q = pinocchio::integrate(robot.model(), q, dt*v);
     BOOST_REQUIRE(isFinite(v));
     BOOST_REQUIRE(isFinite(q));
     t += dt;
@@ -133,19 +133,19 @@ BOOST_AUTO_TEST_CASE ( test_task_com_equality )
   string urdfFileName = package_dirs[0] + "/urdf/romeo.urdf";
   RobotWrapper robot(urdfFileName,
                      package_dirs,
-                     se3::JointModelFreeFlyer(),
+                     pinocchio::JointModelFreeFlyer(),
                      false);
   
-  se3::Data data(robot.model());
+  pinocchio::Data data(robot.model());
   const string srdfFileName = package_dirs[0] + "/srdf/romeo_collision.srdf";
-  se3::srdf::getNeutralConfigurationFromSrdf(robot.model(),srdfFileName);
+  pinocchio::srdf::loadReferenceConfigurations(robot.model(),srdfFileName,false);
   
   //  const unsigned int nv = robot.nv();
-  VectorXd q = robot.model().neutralConfiguration;
+  VectorXd q = neutral(robot.model());
   std::cout << "q: " << q.transpose() << std::endl;
   q(2) += 0.84;
   
-  se3::centerOfMass(robot.model(),data,q);
+  pinocchio::centerOfMass(robot.model(),data,q);
 
   TaskComEquality task("task-com", robot);
 
@@ -156,7 +156,7 @@ BOOST_AUTO_TEST_CASE ( test_task_com_equality )
   BOOST_CHECK(task.Kp().isApprox(Kp));
   BOOST_CHECK(task.Kd().isApprox(Kd));
 
-  Vector3 com_ref = data.com[0] + se3::SE3::Vector3(0.02,0.02,0.02);
+  Vector3 com_ref = data.com[0] + pinocchio::SE3::Vector3(0.02,0.02,0.02);
   TrajectoryBase *traj = new TrajectoryEuclidianConstant("traj_com", com_ref);
   TrajectorySample sample;
 
@@ -183,7 +183,7 @@ BOOST_AUTO_TEST_CASE ( test_task_com_equality )
     BOOST_REQUIRE(isFinite(dv));
 
     v += dt*dv;
-    q = se3::integrate(robot.model(), q, dt*v);
+    q = pinocchio::integrate(robot.model(), q, dt*v);
     BOOST_REQUIRE(isFinite(v));
     BOOST_REQUIRE(isFinite(q));
     t += dt;
@@ -209,7 +209,7 @@ BOOST_AUTO_TEST_CASE ( test_task_joint_posture )
   string urdfFileName = package_dirs[0] + "/urdf/romeo.urdf";
   RobotWrapper robot(urdfFileName,
                      package_dirs,
-                     se3::JointModelFreeFlyer(),
+                     pinocchio::JointModelFreeFlyer(),
                      false);
   const unsigned int na = robot.nv()-6;
 
@@ -234,9 +234,9 @@ BOOST_AUTO_TEST_CASE ( test_task_joint_posture )
   const double dt = 0.001;
   MatrixXd Jpinv(robot.nv(), na);
   double error, error_past=1e100;
-  VectorXd q = robot.model().neutralConfiguration;
+  VectorXd q = neutral(robot.model());
   VectorXd v = VectorXd::Zero(robot.nv());
-  se3::Data data(robot.model());
+  pinocchio::Data data(robot.model());
   for(int i=0; i<max_it; i++)
   {
     robot.computeAllTerms(data, q, v);
@@ -255,7 +255,7 @@ BOOST_AUTO_TEST_CASE ( test_task_joint_posture )
     BOOST_REQUIRE(isFinite(dv));
 
     v += dt*dv;
-    q = se3::integrate(robot.model(), q, dt*v);
+    q = pinocchio::integrate(robot.model(), q, dt*v);
     BOOST_REQUIRE(isFinite(v));
     BOOST_REQUIRE(isFinite(q));
     t += dt;

--- a/unittest/trajectories.cpp
+++ b/unittest/trajectories.cpp
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE ( test_trajectory_se3 )
   using namespace math;
   using namespace std;
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
 
   SE3 M_ref = SE3::Identity();
   VectorXd M_vec(12);

--- a/unittest/tsid-formulation.cpp
+++ b/unittest/tsid-formulation.cpp
@@ -101,21 +101,21 @@ class StandardRomeoInvDynCtrl
   TaskJointPosture * postureTask;
   Vector q;
   Vector v;
-  se3::SE3 H_rf_ref;
-  se3::SE3 H_lf_ref;
+  pinocchio::SE3 H_rf_ref;
+  pinocchio::SE3 H_lf_ref;
 
   StandardRomeoInvDynCtrl() : t(0.)
   {
     vector<string> package_dirs;
     package_dirs.push_back(romeo_model_path);
     const string urdfFileName = package_dirs[0] + "/urdf/romeo.urdf";
-    robot = new RobotWrapper(urdfFileName, package_dirs, se3::JointModelFreeFlyer());
-
+    robot = new RobotWrapper(urdfFileName, package_dirs, pinocchio::JointModelFreeFlyer());
+    
     const string srdfFileName = package_dirs[0] + "/srdf/romeo_collision.srdf";
-    se3::srdf::getNeutralConfigurationFromSrdf(robot->model(),srdfFileName);
-
+    pinocchio::srdf::loadReferenceConfigurations(robot->model(),srdfFileName,false);
+    
     const unsigned int nv = robot->nv();
-    q = robot->model().neutralConfiguration;
+    q = neutral(robot->model());
     std::cout << "q: " << q.transpose() << std::endl;
     q(2) += 0.84;
     v = Vector::Zero(nv);
@@ -125,7 +125,7 @@ class StandardRomeoInvDynCtrl
     // Create the inverse-dynamics formulation
     tsid = new InverseDynamicsFormulationAccForce("tsid", *robot);
     tsid->computeProblemData(t, q, v);
-    const se3::Data & data = tsid->data();
+    const pinocchio::Data & data = tsid->data();
 
     // Add the contact constraints
     Matrix3x contactPoints(3,4);
@@ -210,7 +210,7 @@ BOOST_AUTO_TEST_CASE ( test_invdyn_formulation_acc_force_remove_contact )
                                                        romeo_inv_dyn.rf_frame_name);
   rightFootTask->Kp(kp_RF*Vector::Ones(6));
   rightFootTask->Kd(2.0*rightFootTask->Kp().cwiseSqrt());
-  se3::SE3 H_rf_ref = robot.position(tsid->data(),
+  pinocchio::SE3 H_rf_ref = robot.position(tsid->data(),
                                      robot.model().getJointId(romeo_inv_dyn.rf_frame_name));
   tsid->addMotionTask(*rightFootTask, w_RF, 1);
 
@@ -298,7 +298,7 @@ BOOST_AUTO_TEST_CASE ( test_invdyn_formulation_acc_force_remove_contact )
     }
 
     v += dt*dv;
-    q = se3::integrate(robot.model(), q, dt*v);
+    q = pinocchio::integrate(robot.model(), q, dt*v);
     t += dt;
 
     REQUIRE_FINITE(dv.transpose());
@@ -386,7 +386,7 @@ BOOST_AUTO_TEST_CASE ( test_invdyn_formulation_acc_force )
       PRINT_VECTOR(dv);
       Vector rf_pos = contactRF.getMotionTask().position();
       Vector rf_pos_ref = contactRF.getMotionTask().position_ref();
-      se3::SE3 M_rf, M_rf_ref;
+      pinocchio::SE3 M_rf, M_rf_ref;
       vectorToSE3(rf_pos, M_rf);
       vectorToSE3(rf_pos_ref, M_rf_ref);
       cout<<"RF pos:     "<<rf_pos.transpose()<<endl;
@@ -460,7 +460,7 @@ BOOST_AUTO_TEST_CASE ( test_invdyn_formulation_acc_force )
 //    CHECK_LESS_THAN((M_u*dv + h_u - J_u.transpose()*f).norm(), 1e-6);
 
     v += dt*dv;
-    q = se3::integrate(robot.model(), q, dt*v);
+    q = pinocchio::integrate(robot.model(), q, dt*v);
     t += dt;
 
     REQUIRE_FINITE(dv.transpose());
@@ -711,7 +711,7 @@ BOOST_AUTO_TEST_CASE ( test_invdyn_formulation_acc_force_computation_time )
 
     dv = sol.x.head(nv);
     v += dt*dv;
-    q = se3::integrate(robot.model(), q, dt*v);
+    q = pinocchio::integrate(robot.model(), q, dt*v);
     t += dt;
 
     REQUIRE_FINITE(dv.transpose());


### PR DESCRIPTION
Apply changes to update to pinocchio-v2.1
Should be an easy fix:
* se3 -> pinocchio
* getJacobian -> getFrameJacobian
The only stuff where I am not fully sure is the one for the CoM.
But as far as I understand the current version of centerOfMass computation, specifiying the acceleration triggers the computation of the CoM acceleration.
Anyway unittests are passing on my machine.