### PR TITLE
Add TrajSample.pos(SE3) for python bindings.

### DIFF
--- a/bindings/python/trajectories/trajectory-base.hpp
+++ b/bindings/python/trajectories/trajectory-base.hpp
@@ -23,43 +23,50 @@
 #include <eigenpy/eigenpy.hpp>
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 
+#include <tsid/math/utils.hpp>
 #include "tsid/trajectories/trajectory-base.hpp"
 #include <assert.h>
 namespace tsid
 {
   namespace python
-  {    
+  {
     namespace bp = boost::python;
-    
+    typedef pinocchio::SE3 SE3;
+
     template<typename TrajSample>
     struct TrajectorySamplePythonVisitor
     : public boost::python::def_visitor< TrajectorySamplePythonVisitor<TrajSample> >
     {
-      
-      template<class PyClass>     
+
+      template<class PyClass>
 
       void visit(PyClass& cl) const
       {
         cl
         .def(bp::init<unsigned int>((bp::arg("size")), "Default Constructor with size"))
         .def(bp::init<unsigned int, unsigned int>((bp::arg("pos_size"), bp::arg("vel_size")), "Default Constructor with pos and vel size"))
-        
+
         .def("resize", &TrajectorySamplePythonVisitor::resize, bp::arg("size"))
         .def("resize", &TrajectorySamplePythonVisitor::resize2, bp::args("pos_size", "vel_size"))
-       
+
         .def("pos", &TrajectorySamplePythonVisitor::pos)
         .def("vel", &TrajectorySamplePythonVisitor::vel)
         .def("acc", &TrajectorySamplePythonVisitor::acc)
 
-        .def("pos", &TrajectorySamplePythonVisitor::setpos)
+        .def("pos", &TrajectorySamplePythonVisitor::setpos_vec)
+        .def("pos", &TrajectorySamplePythonVisitor::setpos_se3)
         .def("vel", &TrajectorySamplePythonVisitor::setvel)
         .def("acc", &TrajectorySamplePythonVisitor::setacc)
         ;
       }
-     
-      static void setpos(TrajSample & self, const Eigen::VectorXd pos){
+
+      static void setpos_vec(TrajSample & self, const Eigen::VectorXd pos){
         assert (self.pos.size() == pos.size());
         self.pos = pos;
+      }
+      static void setpos_se3(TrajSample & self, const pinocchio::SE3 & pos){
+        assert (self.pos.size() == 12);
+        tsid::math::SE3ToVector(pos, self.pos);
       }
       static void setvel(TrajSample & self, const Eigen::VectorXd vel){
         assert (self.vel.size() == vel.size());
@@ -84,7 +91,7 @@ namespace tsid
       static Eigen::VectorXd acc(const TrajSample & self){
           return self.acc;
       }
-      
+
       static void expose(const std::string & class_name)
       {
         std::string doc = "Trajectory Sample info.";

--- a/src/trajectories/trajectory-se3.cpp
+++ b/src/trajectories/trajectory-se3.cpp
@@ -27,7 +27,9 @@ namespace tsid
 
     TrajectorySE3Constant::TrajectorySE3Constant(const std::string & name)
       :TrajectoryBase(name)
-    {}
+    {
+      m_sample.resize(12, 6);
+    }
 
     TrajectorySE3Constant::TrajectorySE3Constant(const std::string & name,
                                                  const SE3 & M)
@@ -41,7 +43,7 @@ namespace tsid
     {
       return 6;
     }
-    
+
     void TrajectorySE3Constant::setReference(const pinocchio::SE3 & ref)
     {
       m_sample.resize(12, 6);


### PR DESCRIPTION
This allows to use an SE3 object to set the trajectorie's sample position. 

I was using before this python code to convert the 7-dim q vector to the required 12-dim se3-position vector

```
def base_pos_se3_vector(q):
    """ Convert the q base position into an SE3 object. """
    quad = se3.Quaternion(float(q[6]), float(q[3]), float(q[4]), float(q[5]))
    pos = zero(12)
    pos[:3] = q[:3].reshape(-1, 1)
    pos[3:] = quad.matrix().reshape(-1, 1)
    print(quad.matrix())
    # Yields:
    # [[ 1.    0.    0.  ]
    #  [-0.    1.   -0.04]
    #  [-0.    0.04  1.  ]]
    return pos
```

however, this does not yield the desired / expected result. The reshaping of the `quad.matrix` is done row-wise, where the C++ code in `tsid::math::SE3ToVector` seems to do it column-wise. In practice, this caused issues when tracking a desired orientation. In the above example, the python code would return 

```
pos.T: matrix([[ 0.  ,  0.64,  0.22,  1.  ,  0.  ,  0.  , -0.  ,  1.  , -0.04, -0.  ,  0.04,  1.  ]])
```
where propagating the same q into the invdyn and reading the desired position from the se3-task.position yields

```
pos.T: matrix([[ 0.  ,  0.64,  0.22,  1.  ,  0.  ,  0.  , -0.  ,  1.  , 0.04, -0.  ,  -0.04,  1.  ]])
```

Note the flip of sign at the +-0.04.

PS1: This is my new `base_pos_se3_vector` with the more fail-safe SE3 object:

```
def base_pos_se3_vector(q):
    """ Convert the q base position into an SE3 object. """
    quad = se3.Quaternion(float(q[6]), float(q[3]), float(q[4]), float(q[5]))
    return se3.SE3(quad.matrix(), q[:3].reshape(-1, 1))
```

PS2: Is there a way to get the SE3 object from the 7 entry q vector using a single build in method form pinocchio?