### PR TITLE
Fix python issue #50

### DIFF
--- a/bindings/python/robots/robot-wrapper.hpp
+++ b/bindings/python/robots/robot-wrapper.hpp
@@ -23,15 +23,17 @@
 #include <string>
 #include <eigenpy/eigenpy.hpp>
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
+#include <boost/python/make_constructor.hpp>
 
+#include <pinocchio/bindings/python/parsers/parsers.hpp>
 #include "tsid/robots/robot-wrapper.hpp"
 
 namespace tsid
 {
   namespace python
-  {    
+  {
     namespace bp = boost::python;
-    
+
     template<typename Robot>
     struct RobotPythonVisitor
     : public boost::python::def_visitor< RobotPythonVisitor<Robot> >
@@ -39,18 +41,19 @@ namespace tsid
       typedef std::vector<std::string> std_vec;
       typedef Eigen::Matrix<double,3,Eigen::Dynamic> Matrix3x;
 
-      template<class PyClass>     
+      template<class PyClass >
 
       void visit(PyClass& cl) const
       {
         cl
         .def(bp::init<std::string, std_vec, bool>((bp::arg("filename"), bp::arg("package_dir"), bp::arg("verbose")), "Default constructor without RootJoint."))
         .def(bp::init<pinocchio::Model, bool>((bp::arg("Pinocchio Model"), bp::arg("verbose")), "Default constructor from pinocchio model"))
-        .def(bp::init<std::string, std_vec, pinocchio::JointModelVariant, bool>((bp::arg("filename"), bp::arg("package_dir"), bp::arg("roottype"), bp::arg("verbose")), "Default constructor without RootJoint."))
+        .def(bp::init<std::string, std_vec, pinocchio::JointModelVariant &, bool>((bp::arg("filename"), bp::arg("package_dir"), bp::arg("roottype"), bp::arg("verbose")), "Default constructor without RootJoint."))
+        .def("__init__",bp::make_constructor(RobotPythonVisitor<Robot> ::makeClass))
         .add_property("nq", &Robot::nq)
         .add_property("nv", &Robot::nv)
         .add_property("na", &Robot::na)
-        
+
         .def("model", &RobotPythonVisitor::model)
         .def("data", &RobotPythonVisitor::data)
 
@@ -58,18 +61,18 @@ namespace tsid
         .add_property("gear_ratios", &RobotPythonVisitor::gear_ratios)
         .def("set_rotor_inertias", &RobotPythonVisitor::set_rotor_inertias, bp::arg("inertia vector"))
         .def("set_gear_ratios", &RobotPythonVisitor::set_gear_ratios, bp::arg("gear ratio vector"))
-        
+
         .def("computeAllTerms", &RobotPythonVisitor::computeAllTerms, bp::args("data", "q", "v"), "compute all dynamics")
         .def("com", &RobotPythonVisitor::com, bp::arg("data"))
         .def("com_vel", &RobotPythonVisitor::com_vel, bp::arg("data"))
         .def("com_acc", &RobotPythonVisitor::com_acc, bp::arg("data"))
         .def("Jcom", &RobotPythonVisitor::Jcom, bp::arg("data"))
-        .def("mass", &RobotPythonVisitor::mass, bp::arg("data")) 
+        .def("mass", &RobotPythonVisitor::mass, bp::arg("data"))
         .def("nonLinearEffect", &RobotPythonVisitor::nonLinearEffects, bp::arg("data"))
-        .def("position", &RobotPythonVisitor::position, bp::args("data", "index")) 
+        .def("position", &RobotPythonVisitor::position, bp::args("data", "index"))
         .def("velocity", &RobotPythonVisitor::velocity, bp::args("data", "index"))
         .def("acceleration", &RobotPythonVisitor::acceleration, bp::args("data", "index"))
-        
+
         .def("framePosition", &RobotPythonVisitor::framePosition, bp::args("data", "index"))
         .def("frameVelocity", &RobotPythonVisitor::frameVelocity, bp::args("data", "index"))
         .def("frameAcceleration", &RobotPythonVisitor::frameAcceleration, bp::args("data", "index"))
@@ -77,9 +80,27 @@ namespace tsid
         .def("frameVelocityWorldOriented", &RobotPythonVisitor::frameVelocityWorldOriented, bp::args("data", "index"))
         .def("frameAccelerationWorldOriented", &RobotPythonVisitor::frameAccelerationWorldOriented, bp::args("data", "index"))
         .def("frameClassicAccelerationWorldOriented", &RobotPythonVisitor::frameClassicAccelerationWorldOriented, bp::args("data", "index"))
-   
+
         ;
       }
+
+      static boost::shared_ptr<Robot> makeClass(const std::string &filename,
+                                                const std::vector<std::string>
+                                                &stdvec,
+                                                bp::object & bpObject,
+                                                bool verbose)
+      {
+        std::cout << "Before extraction " << std::endl;
+        pinocchio::JointModelFreeFlyer root_joint =
+            bp::extract<pinocchio::JointModelFreeFlyer>(bpObject)();
+        std::cout << "After extraction " << std::endl;
+        boost::shared_ptr<Robot> p(new tsid::robots::RobotWrapper(filename,
+                                                                  stdvec,
+                                                                  root_joint,
+                                                                  verbose));
+        return p;
+      }
+
       static pinocchio::Model model (const Robot & self){
         return self.model();
       }
@@ -108,10 +129,10 @@ namespace tsid
       }
       static Eigen::Vector3d com_acc (const Robot & self, const pinocchio::Data & data){
         return self.com_acc(data);
-      } 
+      }
       static Matrix3x Jcom (const Robot & self, const pinocchio::Data & data){
         return self.Jcom(data);
-      } 
+      }
       static void computeAllTerms (const Robot & self, pinocchio::Data & data, const Eigen::VectorXd & q, const Eigen::VectorXd & v){
          self.computeAllTerms(data, q, v);
       }

--- a/bindings/python/robots/robot-wrapper.hpp
+++ b/bindings/python/robots/robot-wrapper.hpp
@@ -90,10 +90,8 @@ namespace tsid
                                                 bp::object & bpObject,
                                                 bool verbose)
       {
-        std::cout << "Before extraction " << std::endl;
         pinocchio::JointModelFreeFlyer root_joint =
             bp::extract<pinocchio::JointModelFreeFlyer>(bpObject)();
-        std::cout << "After extraction " << std::endl;
         boost::shared_ptr<Robot> p(new tsid::robots::RobotWrapper(filename,
                                                                   stdvec,
                                                                   root_joint,


### PR DESCRIPTION
This PR adds a method to bindings/python/robots/robot-wrapper.hpp
to read a JointModelFreeFlyer python type and call the appropriate constructor of the RobotWrapper object.
It might be needed to extend this if someone wants to use another joint than a FreeFlyer as a root (but it  looks unlikely to happen).
