### PR TITLE
Angular momentum equality task

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ ADD_REQUIRED_DEPENDENCY("eigen3 >= 3.2.0") # Eigen::Ref appeared from 3.2.0
 #  - If it isn't, nothing happens and the subsequent pkg-config check takes care of everything.
 find_package(catkin QUIET COMPONENTS pinocchio)
 
-ADD_REQUIRED_DEPENDENCY("pinocchio >= 2.0.0")
+ADD_REQUIRED_DEPENDENCY("pinocchio >= 2.2.0")
 
 SET(BOOST_REQUIERED_COMPONENTS filesystem system)
 SET(BOOST_BUILD_COMPONENTS unit_test_framework)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,7 @@ SET(${PROJECT_NAME}_TASKS_HEADERS
     include/tsid/tasks/task-actuation-bounds.hpp
     include/tsid/tasks/task-joint-bounds.hpp
     include/tsid/tasks/task-joint-posture.hpp
+    include/tsid/tasks/task-angular-momentum-equality.hpp
   )
 
 SET(${PROJECT_NAME}_CONTACTS_HEADERS

--- a/bindings/python/formulations/formulation.hpp
+++ b/bindings/python/formulations/formulation.hpp
@@ -98,7 +98,7 @@ namespace tsid
       }
       static bool addActuationTask_Bounds(T & self, tasks::TaskActuationBounds & task, double weight, unsigned int priorityLevel, double transition_duration){
         return self.addActuationTask(task, weight, priorityLevel, transition_duration);
-
+      }
 
       static bool addTask_AM(T & self, tasks::TaskAMEquality & task, double weight, unsigned int priorityLevel){
         TaskLevel *tl = new TaskLevel(task, priorityLevel);

--- a/bindings/python/formulations/formulation.hpp
+++ b/bindings/python/formulations/formulation.hpp
@@ -61,8 +61,8 @@ namespace tsid
         .def("addMotionTask", &InvDynPythonVisitor::addMotionTask_COM, bp::args("task", "weight", "priorityLevel", "transition duration"))
         .def("addMotionTask", &InvDynPythonVisitor::addMotionTask_Joint, bp::args("task", "weight", "priorityLevel", "transition duration"))
         .def("addMotionTask", &InvDynPythonVisitor::addMotionTask_JointBounds, bp::args("task", "weight", "priorityLevel", "transition duration"))
+        .def("addMotionTask", &InvDynPythonVisitor::addMotionTask_AM, bp::args("task", "weight", "priorityLevel", "transition duration"))
         .def("addActuationTask", &InvDynPythonVisitor::addActuationTask_Bounds, bp::args("task", "weight", "priorityLevel", "transition duration"))
-        .def("addTask", &InvDynPythonVisitor::addTask_AM, bp::args("task", "weight", "priorityLevel"))
         .def("updateTaskWeight", &InvDynPythonVisitor::updateTaskWeight, bp::args("task_name", "weight"))
         .def("addRigidContact", &InvDynPythonVisitor::addRigidContact6dDeprecated, bp::args("contact"))
         .def("addRigidContact", &InvDynPythonVisitor::addRigidContact6d, bp::args("contact", "force_reg_weight"))
@@ -96,14 +96,11 @@ namespace tsid
       static bool addMotionTask_JointBounds(T & self, tasks::TaskJointBounds & task, double weight, unsigned int priorityLevel, double transition_duration){
         return self.addMotionTask(task, weight, priorityLevel, transition_duration);
       }
+      static bool addMotionTask_AM(T & self, tasks::TaskAMEquality & task, double weight, unsigned int priorityLevel, double transition_duration){
+        return self.addMotionTask(task, weight, priorityLevel, transition_duration);
+      }
       static bool addActuationTask_Bounds(T & self, tasks::TaskActuationBounds & task, double weight, unsigned int priorityLevel, double transition_duration){
         return self.addActuationTask(task, weight, priorityLevel, transition_duration);
-      }
-
-      static bool addTask_AM(T & self, tasks::TaskAMEquality & task, double weight, unsigned int priorityLevel){
-        TaskLevel *tl = new TaskLevel(task, priorityLevel);
-        self.addTask(tl, weight, priorityLevel);
-        return true;
       }
       static bool updateTaskWeight(T& self, const std::string & task_name, double weight){
         return self.updateTaskWeight(task_name, weight);

--- a/bindings/python/formulations/formulation.hpp
+++ b/bindings/python/formulations/formulation.hpp
@@ -33,6 +33,8 @@
 #include "tsid/tasks/task-com-equality.hpp"
 #include "tsid/tasks/task-actuation-bounds.hpp"
 #include "tsid/tasks/task-joint-bounds.hpp"
+#include "tsid/tasks/task-angular-momentum-equality.hpp"
+
 
 namespace tsid
 {
@@ -60,7 +62,7 @@ namespace tsid
         .def("addMotionTask", &InvDynPythonVisitor::addMotionTask_Joint, bp::args("task", "weight", "priorityLevel", "transition duration"))
         .def("addMotionTask", &InvDynPythonVisitor::addMotionTask_JointBounds, bp::args("task", "weight", "priorityLevel", "transition duration"))
         .def("addActuationTask", &InvDynPythonVisitor::addActuationTask_Bounds, bp::args("task", "weight", "priorityLevel", "transition duration"))
-        
+        .def("addTask", &InvDynPythonVisitor::addTask_AM, bp::args("task", "weight", "priorityLevel"))
         .def("updateTaskWeight", &InvDynPythonVisitor::updateTaskWeight, bp::args("task_name", "weight"))
         .def("addRigidContact", &InvDynPythonVisitor::addRigidContact6dDeprecated, bp::args("contact"))
         .def("addRigidContact", &InvDynPythonVisitor::addRigidContact6d, bp::args("contact", "force_reg_weight"))
@@ -96,6 +98,12 @@ namespace tsid
       }
       static bool addActuationTask_Bounds(T & self, tasks::TaskActuationBounds & task, double weight, unsigned int priorityLevel, double transition_duration){
         return self.addActuationTask(task, weight, priorityLevel, transition_duration);
+
+
+      static bool addTask_AM(T & self, tasks::TaskAMEquality & task, double weight, unsigned int priorityLevel){
+        TaskLevel *tl = new TaskLevel(task, priorityLevel);
+        self.addTask(tl, weight, priorityLevel);
+        return true;
       }
       static bool updateTaskWeight(T& self, const std::string & task_name, double weight){
         return self.updateTaskWeight(task_name, weight);

--- a/bindings/python/robots/robot-wrapper.hpp
+++ b/bindings/python/robots/robot-wrapper.hpp
@@ -77,6 +77,7 @@ namespace tsid
         .def("frameVelocityWorldOriented", &RobotPythonVisitor::frameVelocityWorldOriented, bp::args("data", "index"))
         .def("frameAccelerationWorldOriented", &RobotPythonVisitor::frameAccelerationWorldOriented, bp::args("data", "index"))
         .def("frameClassicAccelerationWorldOriented", &RobotPythonVisitor::frameClassicAccelerationWorldOriented, bp::args("data", "index"))
+        .def("angularMomentumTimeVariation", &RobotPythonVisitor::angularMomentumTimeVariation, bp::arg("data"))
    
         ;
       }
@@ -150,6 +151,9 @@ namespace tsid
       }
       static pinocchio::Motion frameClassicAccelerationWorldOriented(const Robot & self, const pinocchio::Data & data, const pinocchio::Model::FrameIndex & index){
         return self.frameClassicAccelerationWorldOriented(data, index);
+      }
+      static Eigen::Vector3d angularMomentumTimeVariation(const Robot & self, const pinocchio::Data & data){
+        return self.angularMomentumTimeVariation(data);
       }
       static void expose(const std::string & class_name)
       {

--- a/bindings/python/tasks/expose-tasks.hpp
+++ b/bindings/python/tasks/expose-tasks.hpp
@@ -23,6 +23,7 @@
 #include "tsid/bindings/python/tasks/task-joint-posture.hpp"
 #include "tsid/bindings/python/tasks/task-actuation-bounds.hpp"
 #include "tsid/bindings/python/tasks/task-joint-bounds.hpp"
+#include "tsid/bindings/python/tasks/task-am-equality.hpp"
 
 
 namespace tsid
@@ -34,6 +35,7 @@ namespace tsid
     void exposeTaskJointPosture();
     void exposeTaskActuationBounds();
     void exposeTaskJointBounds();
+    void exposeTaskAMEquality();
 
     inline void exposeTasks()
     {
@@ -42,6 +44,7 @@ namespace tsid
       exposeTaskJointPosture();
       exposeTaskActuationBounds();
       exposeTaskJointBounds();
+      exposeTaskAMEquality();
     }
     
   } // namespace python

--- a/bindings/python/tasks/task-am-equality.cpp
+++ b/bindings/python/tasks/task-am-equality.cpp
@@ -1,0 +1,31 @@
+//
+// Copyright (c) 2018 CNRS
+//
+// This file is part of tsid
+// tsid is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+// tsid is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Lesser Public License for more details. You should have
+// received a copy of the GNU Lesser General Public License along with
+// tsid If not, see
+// <http://www.gnu.org/licenses/>.
+//
+
+#include "tsid/bindings/python/tasks/task-am-equality.hpp"
+#include "tsid/bindings/python/tasks/expose-tasks.hpp"
+
+namespace tsid
+{
+  namespace python
+  {
+    void exposeTaskAMEquality()
+    {
+      TaskAMEqualityPythonVisitor<tsid::tasks::TaskAMEquality>::expose("TaskAMEquality");
+    }
+  }
+}
+

--- a/bindings/python/tasks/task-am-equality.hpp
+++ b/bindings/python/tasks/task-am-equality.hpp
@@ -48,7 +48,7 @@ namespace tsid
         .def(bp::init<std::string, robots::RobotWrapper &> ((bp::arg("name"), bp::arg("robot")), "Default Constructor"))
         .add_property("dim", &TaskAM::dim, "return dimension size")
         .def("setReference", &TaskAMEqualityPythonVisitor::setReference, bp::arg("ref"))
-        .add_property("getDesireddMomentum", bp::make_function(&TaskAMEqualityPythonVisitor::getDesireddMomentum, bp::return_value_policy<bp::copy_const_reference>()), "Return Acc_desired")
+        .add_property("getDesiredMomentumDerivative", bp::make_function(&TaskAMEqualityPythonVisitor::getDesiredMomentumDerivative, bp::return_value_policy<bp::copy_const_reference>()), "Return dL_desired")
         .def("getdMomentum", &TaskAMEqualityPythonVisitor::getdMomentum, bp::arg("dv"))
         .add_property("momentum_error", bp::make_function(&TaskAMEqualityPythonVisitor::momentum_error, bp::return_value_policy<bp::copy_const_reference>()))
         .add_property("momentum", bp::make_function(&TaskAMEqualityPythonVisitor::momentum, bp::return_value_policy<bp::copy_const_reference>()))
@@ -79,8 +79,8 @@ namespace tsid
       static void setReference(TaskAM & self, const trajectories::TrajectorySample & ref){
         self.setReference(ref);
       }
-      static const Eigen::Vector3d & getDesireddMomentum(const TaskAM & self){
-        return self.getDesireddMomentum();
+      static const Eigen::Vector3d & getDesiredMomentumDerivative(const TaskAM & self){
+        return self.getDesiredMomentumDerivative();
       }
       static Eigen::Vector3d getdMomentum (TaskAM & self, const Eigen::VectorXd dv){
         return self.getdMomentum(dv);

--- a/bindings/python/tasks/task-am-equality.hpp
+++ b/bindings/python/tasks/task-am-equality.hpp
@@ -1,0 +1,127 @@
+//
+// Copyright (c) 2018 CNRS
+//
+// This file is part of tsid
+// tsid is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+// tsid is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Lesser Public License for more details. You should have
+// received a copy of the GNU Lesser General Public License along with
+// tsid If not, see
+// <http://www.gnu.org/licenses/>.
+//
+
+#ifndef __tsid_python_task_am_hpp__
+#define __tsid_python_task_am_hpp__
+
+#include <boost/python.hpp>
+#include <string>
+#include <eigenpy/eigenpy.hpp>
+#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
+
+#include "tsid/tasks/task-angular-momentum-equality.hpp"
+#include "tsid/robots/robot-wrapper.hpp"
+#include "tsid/trajectories/trajectory-base.hpp"
+#include "tsid/math/constraint-equality.hpp"
+#include "tsid/math/constraint-base.hpp"
+namespace tsid
+{
+  namespace python
+  {    
+    namespace bp = boost::python;
+
+    template<typename TaskAM>
+    struct TaskAMEqualityPythonVisitor
+    : public boost::python::def_visitor< TaskAMEqualityPythonVisitor<TaskAM> >
+    {
+      
+      template<class PyClass>     
+      
+
+      void visit(PyClass& cl) const
+      {
+        cl
+        .def(bp::init<std::string, robots::RobotWrapper &> ((bp::arg("name"), bp::arg("robot")), "Default Constructor"))
+        .add_property("dim", &TaskAM::dim, "return dimension size")
+        .def("setReference", &TaskAMEqualityPythonVisitor::setReference, bp::arg("ref"))
+        .add_property("getDesireddMomentum", bp::make_function(&TaskAMEqualityPythonVisitor::getDesireddMomentum, bp::return_value_policy<bp::copy_const_reference>()), "Return Acc_desired")
+        .def("getdMomentum", &TaskAMEqualityPythonVisitor::getdMomentum, bp::arg("dv"))
+        .add_property("momentum_error", bp::make_function(&TaskAMEqualityPythonVisitor::momentum_error, bp::return_value_policy<bp::copy_const_reference>()))
+        .add_property("momentum", bp::make_function(&TaskAMEqualityPythonVisitor::momentum, bp::return_value_policy<bp::copy_const_reference>()))
+        .add_property("momentum_ref", bp::make_function(&TaskAMEqualityPythonVisitor::momentum_ref, bp::return_value_policy<bp::copy_const_reference>()))
+        .add_property("dmomentum_ref", bp::make_function(&TaskAMEqualityPythonVisitor::dmomentum_ref, bp::return_value_policy<bp::copy_const_reference>()))
+        .add_property("Kp", bp::make_function(&TaskAMEqualityPythonVisitor::Kp, bp::return_value_policy<bp::copy_const_reference>()))
+        .add_property("Kd", bp::make_function(&TaskAMEqualityPythonVisitor::Kd, bp::return_value_policy<bp::copy_const_reference>()))
+        .def("setKp", &TaskAMEqualityPythonVisitor::setKp, bp::arg("Kp"))
+        .def("setKd", &TaskAMEqualityPythonVisitor::setKd, bp::arg("Kd"))
+        .def("compute", &TaskAMEqualityPythonVisitor::compute, bp::args("t", "q", "v", "data"))
+        .def("getConstraint",  &TaskAMEqualityPythonVisitor::getConstraint)
+        .add_property("name", &TaskAMEqualityPythonVisitor::name)
+        ;
+      }
+      static std::string name(TaskAM & self){
+        std::string name = self.name();
+        return name;
+      }
+      static math::ConstraintEquality compute(TaskAM & self, const double t, const Eigen::VectorXd & q, const Eigen::VectorXd & v, const pinocchio::Data & data){
+        self.compute(t, q, v, data);
+        math::ConstraintEquality cons(self.getConstraint().name(), self.getConstraint().matrix(), self.getConstraint().vector());
+        return cons;
+      }
+      static math::ConstraintEquality getConstraint(const TaskAM & self){
+        math::ConstraintEquality cons(self.getConstraint().name(), self.getConstraint().matrix(), self.getConstraint().vector());
+        return cons;
+      }
+      static void setReference(TaskAM & self, const trajectories::TrajectorySample & ref){
+        self.setReference(ref);
+      }
+      static const Eigen::Vector3d & getDesireddMomentum(const TaskAM & self){
+        return self.getDesireddMomentum();
+      }
+      static Eigen::Vector3d getdMomentum (TaskAM & self, const Eigen::VectorXd dv){
+        return self.getdMomentum(dv);
+      }
+      static const Eigen::Vector3d & momentum_error(const TaskAM & self){
+        return self.momentum_error();
+      }
+      static const Eigen::Vector3d & momentum (const TaskAM & self){
+        return self.momentum();
+      }
+      static const Eigen::VectorXd & momentum_ref (const TaskAM & self){
+        return self.momentum_ref();
+      }
+      static const Eigen::VectorXd & dmomentum_ref (const TaskAM & self){
+        return self.dmomentum_ref();
+      }     
+      static const Eigen::Vector3d & Kp (TaskAM & self){
+        return self.Kp();
+      }  
+      static const Eigen::Vector3d & Kd (TaskAM & self){
+        return self.Kd();
+      }    
+      static void setKp (TaskAM & self, const::Eigen::VectorXd Kp){
+        return self.Kp(Kp);
+      }
+      static void setKd (TaskAM & self, const::Eigen::VectorXd Kv){
+        return self.Kd(Kv);
+      }
+      static void expose(const std::string & class_name)
+      {
+        std::string doc = "TaskAMEqualityPythonVisitor info.";
+        bp::class_<TaskAM>(class_name.c_str(),
+                          doc.c_str(),
+                          bp::no_init)
+        .def(TaskAMEqualityPythonVisitor<TaskAM>());
+
+        bp::register_ptr_to_python< boost::shared_ptr<math::ConstraintBase> >();
+      }
+    };
+  }
+}
+
+
+#endif // ifndef __tsid_python_task_am_hpp__

--- a/bindings/python/tasks/task-am-equality.hpp
+++ b/bindings/python/tasks/task-am-equality.hpp
@@ -17,7 +17,7 @@
 
 #ifndef __tsid_python_task_am_hpp__
 #define __tsid_python_task_am_hpp__
-
+#include <pinocchio/fwd.hpp>
 #include <boost/python.hpp>
 #include <string>
 #include <eigenpy/eigenpy.hpp>

--- a/include/tsid/robots/robot-wrapper.hpp
+++ b/include/tsid/robots/robot-wrapper.hpp
@@ -165,7 +165,10 @@ namespace tsid
       void frameJacobianLocal(const Data & data,
                               const Model::FrameIndex index,
                               Data::Matrix6x & J) const;
-      
+
+      const Data::Matrix6x & momentumJacobian(const Data & data) const;
+
+
     protected:
       
       void init();

--- a/include/tsid/robots/robot-wrapper.hpp
+++ b/include/tsid/robots/robot-wrapper.hpp
@@ -168,6 +168,8 @@ namespace tsid
 
       const Data::Matrix6x & momentumJacobian(const Data & data) const;
 
+      Vector3 angularMomentumTimeVariation(const Data & data) const;
+
 
     protected:
       

--- a/include/tsid/tasks/task-angular-momentum-equality.hpp
+++ b/include/tsid/tasks/task-angular-momentum-equality.hpp
@@ -59,7 +59,7 @@ namespace tsid
       void setReference(const TrajectorySample & ref);
       const TrajectorySample & getReference() const;
 
-      const Vector3 & getDesireddMomentum() const;
+      const Vector3 & getDesiredMomentumDerivative() const;
       Vector3 getdMomentum(ConstRefVector dv) const;
 
       const Vector3 & momentum_error() const;

--- a/include/tsid/tasks/task-angular-momentum-equality.hpp
+++ b/include/tsid/tasks/task-angular-momentum-equality.hpp
@@ -1,0 +1,88 @@
+//
+// Copyright (c) 2017 CNRS
+//
+// This file is part of tsid
+// tsid is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+// tsid is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Lesser Public License for more details. You should have
+// received a copy of the GNU Lesser General Public License along with
+// tsid If not, see
+// <http://www.gnu.org/licenses/>.
+//
+
+#ifndef __invdyn_task_am_equality_hpp__
+#define __invdyn_task_am_equality_hpp__
+
+#include "tsid/math/fwd.hpp"
+#include "tsid/tasks/task-base.hpp"
+#include "tsid/trajectories/trajectory-base.hpp"
+#include "tsid/math/constraint-equality.hpp"
+#include <pinocchio/multibody/data.hpp>
+
+namespace tsid
+{
+  namespace tasks
+  {
+
+    class TaskAMEquality : public TaskBase
+    {
+    public:
+      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      
+      typedef math::Index Index;
+      typedef trajectories::TrajectorySample TrajectorySample;
+      typedef math::Vector Vector;
+      typedef math::Vector3 Vector3;
+      typedef math::ConstraintEquality ConstraintEquality;
+      typedef pinocchio::Data::Matrix6x Matrix6x;
+      typedef pinocchio::Data Data;
+
+      TaskAMEquality(const std::string & name, 
+                      RobotWrapper & robot);
+
+      int dim() const;
+
+      const ConstraintBase & compute(const double t,
+                                     ConstRefVector q,
+                                     ConstRefVector v,
+                                     const Data & data);
+
+      const ConstraintBase & getConstraint() const;
+
+      void setReference(const TrajectorySample & ref);
+      const TrajectorySample & getReference() const;
+
+      const Vector3 & getDesireddMomentum() const;
+      Vector3 getdMomentum(ConstRefVector dv) const;
+
+      const Vector3 & momentum_error() const;
+      const Vector3 & momentum() const;
+      const Vector & momentum_ref() const;
+      const Vector & dmomentum_ref() const;
+
+      const Vector3 & Kp();
+      const Vector3 & Kd();
+      void Kp(ConstRefVector Kp);
+      void Kd(ConstRefVector Kp);
+
+    protected:
+      Vector3 m_Kp;
+      Vector3 m_Kd;
+      Vector3 m_L_error, m_dL_error;
+      Vector3 m_dL_des;
+      
+      Vector3 m_drift;
+      Vector3 m_L, m_dL;
+      TrajectorySample m_ref;
+      ConstraintEquality m_constraint;
+    };
+    
+  }
+}
+
+#endif // ifndef __invdyn_task_am_equality_hpp__

--- a/include/tsid/tasks/task-angular-momentum-equality.hpp
+++ b/include/tsid/tasks/task-angular-momentum-equality.hpp
@@ -19,7 +19,7 @@
 #define __invdyn_task_am_equality_hpp__
 
 #include "tsid/math/fwd.hpp"
-#include "tsid/tasks/task-base.hpp"
+#include "tsid/tasks/task-motion.hpp"
 #include "tsid/trajectories/trajectory-base.hpp"
 #include "tsid/math/constraint-equality.hpp"
 
@@ -31,7 +31,7 @@ namespace tsid
   namespace tasks
   {
 
-    class TaskAMEquality : public TaskBase
+    class TaskAMEquality : public TaskMotion
     {
     public:
       EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/include/tsid/tasks/task-angular-momentum-equality.hpp
+++ b/include/tsid/tasks/task-angular-momentum-equality.hpp
@@ -22,6 +22,8 @@
 #include "tsid/tasks/task-base.hpp"
 #include "tsid/trajectories/trajectory-base.hpp"
 #include "tsid/math/constraint-equality.hpp"
+
+#include <pinocchio/multibody/model.hpp>
 #include <pinocchio/multibody/data.hpp>
 
 namespace tsid
@@ -40,7 +42,7 @@ namespace tsid
       typedef math::Vector3 Vector3;
       typedef math::ConstraintEquality ConstraintEquality;
       typedef pinocchio::Data::Matrix6x Matrix6x;
-      typedef pinocchio::Data Data;
+
 
       TaskAMEquality(const std::string & name, 
                       RobotWrapper & robot);

--- a/script/test_Tasks.py
+++ b/script/test_Tasks.py
@@ -189,7 +189,7 @@ data = robot.data()
 
 q = robot.model().neutralConfiguration
 q[2] += 0.84
-print "q:", q.transpose()
+print ("q:", q.transpose())
 
 taskAM = tsid.TaskAMEquality("task-AM", robot)
 
@@ -230,10 +230,10 @@ for i in range(0, max_it):
     assert error - error_past < 1e-4
     error_past = error
     if error < 1e-8:
-        print "Success Convergence"
+        print ("Success Convergence")
         break
     if i%100 == 0:
-        print "Time :", t, "Momentum error :", error
+        print ("Time :", t, "Momentum error :", error)
 
 
 print("All test is done")

--- a/script/test_Tasks.py
+++ b/script/test_Tasks.py
@@ -1,4 +1,4 @@
-import pinocchio as se3
+import pinocchio as pin
 import tsid
 import numpy as np
 import copy
@@ -12,9 +12,9 @@ import os
 filename = str(os.path.dirname(os.path.abspath(__file__)))
 path = filename + '/../models/romeo'
 urdf = path + '/urdf/romeo.urdf'
-vector = se3.StdVec_StdString()
+vector = pin.StdVec_StdString()
 vector.extend(item for item in path)
-robot = tsid.RobotWrapper(urdf, vector, se3.JointModelFreeFlyer(), False)
+robot = tsid.RobotWrapper(urdf, vector, pin.JointModelFreeFlyer(), False)
 model = robot.model()
 data = robot.data()
 
@@ -22,7 +22,7 @@ q = robot.model().neutralConfiguration
 q[2] += 0.84
 print("q:", q.transpose())
 
-se3.centerOfMass(model, data, q)
+pin.centerOfMass(model, data, q)
 
 taskCOM = tsid.TaskComEquality("task-com", robot)
 
@@ -56,7 +56,7 @@ for i in range(0, max_it):
 
     assert np.linalg.norm(Jpinv*const.matrix, 2) - 1.0 < tol
     v += dt*dv
-    q = se3.integrate(model, q, dt * v)
+    q = pin.integrate(model, q, dt * v)
     t += dt
 
     error = np.linalg.norm(taskCOM.position_error, 2)
@@ -105,7 +105,7 @@ for i in range(0, max_it):
 
     assert np.linalg.norm(Jpinv*const.matrix, 2) - 1.0 < tol
     v += dt*dv
-    q = se3.integrate(model, q, dt * v)
+    q = pin.integrate(model, q, dt * v)
     t += dt
 
     error = np.linalg.norm(task_joint.position_error, 2)
@@ -136,7 +136,7 @@ task_se3.setKd(Kd)
 assert np.linalg.norm(Kp - task_se3.Kp ,2) < tol
 assert np.linalg.norm(Kd - task_se3.Kd ,2) < tol
 
-M_ref =se3.SE3.Random()
+M_ref =pin.SE3.Random()
 
 traj = tsid.TrajectorySE3Constant("traj_se3", M_ref)
 sample = tsid.TrajectorySample(0)
@@ -159,7 +159,7 @@ for i in range(0, max_it):
     assert np.linalg.norm(Jpinv*const.matrix, 2) - 1.0 < tol
 
     v += dt*dv
-    q = se3.integrate(model, q, dt * v)
+    q = pin.integrate(model, q, dt * v)
     t += dt
 
     error = np.linalg.norm(task_se3.position_error, 2)
@@ -181,9 +181,9 @@ import os
 filename = str(os.path.dirname(os.path.abspath(__file__)))
 path = filename + '/../models/romeo'
 urdf = path + '/urdf/romeo.urdf'
-vector = se3.StdVec_StdString()
+vector = pin.StdVec_StdString()
 vector.extend(item for item in path)
-robot = tsid.RobotWrapper(urdf, vector, se3.JointModelFreeFlyer(), False)
+robot = tsid.RobotWrapper(urdf, vector, pin.JointModelFreeFlyer(), False)
 model = robot.model()
 data = robot.data()
 
@@ -223,7 +223,7 @@ for i in range(0, max_it):
 
     assert np.linalg.norm(Jpinv*const.matrix, 2) - 1.0 < tol
     v += dt*dv
-    q = se3.integrate(model, q, dt * v)
+    q = pin.integrate(model, q, dt * v)
     t += dt
 
     error = np.linalg.norm(taskAM.momentum_error, 2)

--- a/script/test_Tasks.py
+++ b/script/test_Tasks.py
@@ -18,7 +18,10 @@ robot = tsid.RobotWrapper(urdf, vector, pin.JointModelFreeFlyer(), False)
 model = robot.model()
 data = robot.data()
 
-q = robot.model().neutralConfiguration
+srdf = path + '/srdf/romeo_collision.srdf'
+pin.loadReferenceConfigurations(model, srdf, False)
+q = model.referenceConfigurations["half_sitting"]
+
 q[2] += 0.84
 print("q:", q.transpose())
 
@@ -72,7 +75,8 @@ print("")
 print("Test Task Joint Posture")
 print("")
 
-q = robot.model().neutralConfiguration
+
+q = model.referenceConfigurations["half_sitting"]
 q[2] += 0.84
 
 task_joint = tsid.TaskJointPosture("task-posture", robot)
@@ -122,7 +126,8 @@ print("Test Task SE3")
 print("")
 
 
-q = robot.model().neutralConfiguration
+
+q = model.referenceConfigurations["half_sitting"]
 q[2] += 0.84
 
 task_se3 = tsid.TaskSE3Equality("task-se3", robot, "RWristPitch")
@@ -187,7 +192,10 @@ robot = tsid.RobotWrapper(urdf, vector, pin.JointModelFreeFlyer(), False)
 model = robot.model()
 data = robot.data()
 
-q = robot.model().neutralConfiguration
+srdf = path + '/srdf/romeo_collision.srdf'
+pin.loadReferenceConfigurations(model, srdf, False)
+q = model.referenceConfigurations["half_sitting"]
+
 q[2] += 0.84
 print ("q:", q.transpose())
 

--- a/script/test_Tasks.py
+++ b/script/test_Tasks.py
@@ -171,5 +171,71 @@ for i in range(0, max_it):
     if i%100 == 0:
         print("Time :", t, "EE pos error :", error, "EE vel error :", np.linalg.norm(task_se3.velocity_error, 2))
 
+
+print ("")
+print ("Test Task Angular Momentum")
+print ("")
+
+tol = 1e-5
+import os
+filename = str(os.path.dirname(os.path.abspath(__file__)))
+path = filename + '/../models/romeo'
+urdf = path + '/urdf/romeo.urdf'
+vector = se3.StdVec_StdString()
+vector.extend(item for item in path)
+robot = tsid.RobotWrapper(urdf, vector, se3.JointModelFreeFlyer(), False)
+model = robot.model()
+data = robot.data()
+
+q = robot.model().neutralConfiguration
+q[2] += 0.84
+print "q:", q.transpose()
+
+taskAM = tsid.TaskAMEquality("task-AM", robot)
+
+Kp = 100 * np.matrix(np.ones(3)).transpose()
+Kd = 20.0 * np.matrix(np.ones(3)).transpose()
+taskAM.setKp(Kp)
+taskAM.setKd(Kd)
+
+assert np.linalg.norm(Kp - taskAM.Kp ,2) < tol
+assert np.linalg.norm(Kd - taskAM.Kd ,2) < tol
+
+am_ref  =np.matrix(np.zeros(3)).transpose()
+traj = tsid.TrajectoryEuclidianConstant("traj_se3", am_ref)
+sample = tsid.TrajectorySample(0)
+
+t = 0.0
+dt = 0.001
+max_it = 1000
+Jpinv = np.matrix(np.zeros((robot.nv, 3)))
+error_past = 1e100
+v = np.matrix(np.random.randn(robot.nv)).transpose()
+
+for i in range(0, max_it):
+    robot.computeAllTerms(data, q, v)
+    sample = traj.computeNext()
+    taskAM.setReference(sample)
+    const = taskAM.compute(t, q, v, data)
+
+    Jpinv = np.linalg.pinv(const.matrix, 1e-5)
+    dv = Jpinv * const.vector
+
+    assert np.linalg.norm(Jpinv*const.matrix, 2) - 1.0 < tol
+    v += dt*dv
+    q = se3.integrate(model, q, dt * v)
+    t += dt
+
+    error = np.linalg.norm(taskAM.momentum_error, 2)
+    assert error - error_past < 1e-4
+    error_past = error
+    if error < 1e-8:
+        print "Success Convergence"
+        break
+    if i%100 == 0:
+        print "Time :", t, "Momentum error :", error
+
+
 print("All test is done")
+
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,6 +37,7 @@ SET(${LIBRARY_NAME}_TASKS_SOURCES
     tasks/task-joint-posture.cpp
     tasks/task-motion.cpp
     tasks/task-se3-equality.cpp
+    tasks/task-angular-momentum-equality.cpp
   )
 
 SET(${LIBRARY_NAME}_CONTACTS_SOURCES

--- a/src/robots/robot-wrapper.cpp
+++ b/src/robots/robot-wrapper.cpp
@@ -316,6 +316,10 @@ namespace tsid
     {
       return data.Ag;
     }
+
+    Vector3 RobotWrapper::angularMomentumTimeVariation(const Data & data) const{
+      return pinocchio::computeCentroidalMomentumTimeVariation(m_model, const_cast<Data&>(data)).angular();
+    }
     
     //    const Vector3 & com(Data & data,const Vector & q,
     //                        const bool computeSubtreeComs = true,

--- a/src/robots/robot-wrapper.cpp
+++ b/src/robots/robot-wrapper.cpp
@@ -23,6 +23,7 @@
 #include <pinocchio/algorithm/compute-all-terms.hpp>
 #include <pinocchio/algorithm/jacobian.hpp>
 #include <pinocchio/algorithm/frames.hpp>
+#include <pinocchio/algorithm/centroidal.hpp>
 
 using namespace pinocchio;
 using namespace tsid::math;
@@ -89,6 +90,7 @@ namespace tsid
       //      pinocchio::centerOfMass(m_model, data, q,v,false);
       pinocchio::framesForwardKinematics(m_model, data);
       pinocchio::centerOfMass(m_model, data, q, v, Eigen::VectorXd::Zero(nv()));
+      pinocchio::ccrba(m_model, data, q, v);
     }
     
     const Vector & RobotWrapper::rotor_inertias() const
@@ -308,6 +310,11 @@ namespace tsid
                                           Data::Matrix6x & J) const
     {
       return pinocchio::getFrameJacobian(m_model, data, index, pinocchio::LOCAL, J);
+    }
+
+    const Data::Matrix6x & RobotWrapper::momentumJacobian(const Data & data) const
+    {
+      return data.Ag;
     }
     
     //    const Vector3 & com(Data & data,const Vector & q,

--- a/src/tasks/task-angular-momentum-equality.cpp
+++ b/src/tasks/task-angular-momentum-equality.cpp
@@ -130,9 +130,9 @@ namespace tsid
       // compute momentum Jacobian at next time step assuming zero acc
       double dt = 1e-3;
       const Vector & q_next = pinocchio::integrate(m_robot.model(), q, dt*v);
-      Data data_ccrba = data;
-      pinocchio::ccrba(m_robot.model(), data_ccrba, q_next, v);
-      const Matrix6x & J_am_next = m_robot.momentumJacobian(data_ccrba);
+      Data data_next = data;
+      m_robot.computeAllTerms(data_next, q_next, v);
+      const Matrix6x & J_am_next = m_robot.momentumJacobian(data_next);
       m_drift = (J_am_next.bottomRows(3) - J_am.bottomRows(3))* v / dt;
 
       m_constraint.setMatrix(J_am.bottomRows(3));

--- a/src/tasks/task-angular-momentum-equality.cpp
+++ b/src/tasks/task-angular-momentum-equality.cpp
@@ -109,7 +109,7 @@ namespace tsid
     }
 
     const ConstraintBase & TaskAMEquality::compute(const double ,
-                                                    ConstRefVector q,
+                                                    ConstRefVector ,
                                                     ConstRefVector v,
                                                     const Data & data)
     {
@@ -126,15 +126,8 @@ namespace tsid
 //      std::cout<<m_name<<" errors: "<<m_L_error.norm()<<" "
 //        <<m_dL_error.norm()<<std::endl;
 #endif
-      // Del Prete's quick and dirty way to compute drift
-      // compute momentum Jacobian at next time step assuming zero acc
-      double dt = 1e-3;
-      const Vector & q_next = pinocchio::integrate(m_robot.model(), q, dt*v);
-      Data data_next = data;
-      m_robot.computeAllTerms(data_next, q_next, v);
-      const Matrix6x & J_am_next = m_robot.momentumJacobian(data_next);
-      m_drift = (J_am_next.bottomRows(3) - J_am.bottomRows(3))* v / dt;
 
+      m_drift = pinocchio::computeCentroidalMomentumTimeVariation(m_robot.model(), const_cast<Data&>(data)).angular();
       m_constraint.setMatrix(J_am.bottomRows(3));
       m_constraint.setVector(m_dL_des - m_drift);
 

--- a/src/tasks/task-angular-momentum-equality.cpp
+++ b/src/tasks/task-angular-momentum-equality.cpp
@@ -123,8 +123,8 @@ namespace tsid
                 + m_ref.acc;
 
 #ifndef NDEBUG
-      std::cout<<m_name<<" errors: "<<m_L_error.norm()<<" "
-        <<m_dL_error.norm()<<std::endl;
+//      std::cout<<m_name<<" errors: "<<m_L_error.norm()<<" "
+//        <<m_dL_error.norm()<<std::endl;
 #endif
       // Del Prete's quick and dirty way to compute drift
       // compute momentum Jacobian at next time step assuming zero acc

--- a/src/tasks/task-angular-momentum-equality.cpp
+++ b/src/tasks/task-angular-momentum-equality.cpp
@@ -30,7 +30,7 @@ namespace tsid
 
     TaskAMEquality::TaskAMEquality(const std::string & name,
                                      RobotWrapper & robot):
-      TaskBase(name, robot),
+      TaskMotion(name, robot),
       m_constraint(name, 3, robot.nv())
     {
       m_Kp.setZero(3);

--- a/src/tasks/task-angular-momentum-equality.cpp
+++ b/src/tasks/task-angular-momentum-equality.cpp
@@ -127,7 +127,7 @@ namespace tsid
 //        <<m_dL_error.norm()<<std::endl;
 #endif
 
-      m_drift = pinocchio::computeCentroidalMomentumTimeVariation(m_robot.model(), const_cast<Data&>(data)).angular();
+      m_drift = m_robot.angularMomentumTimeVariation(data);
       m_constraint.setMatrix(J_am.bottomRows(3));
       m_constraint.setVector(m_dL_des - m_drift);
 

--- a/src/tasks/task-angular-momentum-equality.cpp
+++ b/src/tasks/task-angular-momentum-equality.cpp
@@ -1,0 +1,145 @@
+//
+// Copyright (c) 2017 CNRS
+//
+// This file is part of tsid
+// tsid is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+// tsid is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Lesser Public License for more details. You should have
+// received a copy of the GNU Lesser General Public License along with
+// tsid If not, see
+// <http://www.gnu.org/licenses/>.
+//
+
+#include "tsid/tasks/task-angular-momentum-equality.hpp"
+#include "tsid/robots/robot-wrapper.hpp"
+#include <pinocchio/algorithm/joint-configuration.hpp>
+#include <pinocchio/algorithm/centroidal.hpp>
+
+namespace tsid
+{
+  namespace tasks
+  {
+    using namespace math;
+    using namespace trajectories;
+    using namespace pinocchio;
+
+    TaskAMEquality::TaskAMEquality(const std::string & name,
+                                     RobotWrapper & robot):
+      TaskBase(name, robot),
+      m_constraint(name, 3, robot.nv())
+    {
+      m_Kp.setZero(3);
+      m_Kd.setZero(3);
+      m_L_error.setZero(3);
+      m_dL_error.setZero(3);
+      m_L.setZero(3);
+      m_dL.setZero(3);
+      m_dL_des.setZero(3);
+    }
+
+    int TaskAMEquality::dim() const
+    {
+      //return self._mask.sum ()
+      return 3;
+    }
+
+    const Vector3 & TaskAMEquality::Kp(){ return m_Kp; }
+
+    const Vector3 & TaskAMEquality::Kd(){ return m_Kd; }
+
+    void TaskAMEquality::Kp(ConstRefVector Kp)
+    {
+      assert(Kp.size()==3);
+      m_Kp = Kp;
+    }
+
+    void TaskAMEquality::Kd(ConstRefVector Kd)
+    {
+      assert(Kd.size()==3);
+      m_Kd = Kd;
+    }
+
+    void TaskAMEquality::setReference(const TrajectorySample & ref)
+    {
+      m_ref = ref;
+    }
+
+    const TrajectorySample & TaskAMEquality::getReference() const
+    {
+      return m_ref;
+    }
+
+    const Vector3 & TaskAMEquality::getDesireddMomentum() const
+    {
+      return m_dL_des;
+    }
+
+    Vector3 TaskAMEquality::getdMomentum(ConstRefVector dv) const
+    {
+      return m_constraint.matrix()*dv - m_drift;
+    }
+
+    const Vector3 & TaskAMEquality::momentum_error() const
+    {
+      return m_L_error;
+    }
+
+    const Vector3 & TaskAMEquality::momentum() const
+    {
+      return m_L;
+    }
+    const Vector & TaskAMEquality::momentum_ref() const
+    {
+      return m_ref.vel;
+    }
+
+    const Vector & TaskAMEquality::dmomentum_ref() const
+    {
+      return m_ref.acc;
+    }
+
+    const ConstraintBase & TaskAMEquality::getConstraint() const
+    {
+      return m_constraint;
+    }
+
+    const ConstraintBase & TaskAMEquality::compute(const double ,
+                                                    ConstRefVector q,
+                                                    ConstRefVector v,
+                                                    const Data & data)
+    {
+      // Compute errors
+      // Get momentum jacobian
+      const Matrix6x & J_am = m_robot.momentumJacobian(data);
+      m_L = J_am.bottomRows(3) * v;
+      m_L_error = m_L - m_ref.vel;
+
+      m_dL_des = - m_Kp.cwiseProduct(m_L_error)
+                + m_ref.acc;
+
+#ifndef NDEBUG
+      std::cout<<m_name<<" errors: "<<m_L_error.norm()<<" "
+        <<m_dL_error.norm()<<std::endl;
+#endif
+      // Del Prete's quick and dirty way to compute drift
+      // compute momentum Jacobian at next time step assuming zero acc
+      double dt = 1e-3;
+      const Vector & q_next = pinocchio::integrate(m_robot.model(), q, dt*v);
+      Data data_ccrba = data;
+      pinocchio::ccrba(m_robot.model(), data_ccrba, q_next, v);
+      const Matrix6x & J_am_next = m_robot.momentumJacobian(data_ccrba);
+      m_drift = (J_am_next.bottomRows(3) - J_am.bottomRows(3))* v / dt;
+
+      m_constraint.setMatrix(J_am.bottomRows(3));
+      m_constraint.setVector(m_dL_des - m_drift);
+
+      return m_constraint;
+    }
+    
+  }
+}

--- a/src/tasks/task-angular-momentum-equality.cpp
+++ b/src/tasks/task-angular-momentum-equality.cpp
@@ -74,7 +74,7 @@ namespace tsid
       return m_ref;
     }
 
-    const Vector3 & TaskAMEquality::getDesireddMomentum() const
+    const Vector3 & TaskAMEquality::getDesiredMomentumDerivative() const
     {
       return m_dL_des;
     }


### PR DESCRIPTION
Hello, I took back the original work from @ggory15 from his previous closed PR (https://github.com/stack-of-tasks/tsid/pull/44) and tried to address all the changes requested. 

The main change that remain to be done is here: 
```C++
      // Del Prete's quick and dirty way to compute drift
      // compute momentum Jacobian at next time step assuming zero acc
      double dt = 1e-3;
      const Vector & q_next = pinocchio::integrate(m_robot.model(), q, dt*v);
      Data data_next = data;
      m_robot.computeAllTerms(data_next, q_next, v);
      const Matrix6x & J_am_next = m_robot.momentumJacobian(data_next);
      m_drift = (J_am_next.bottomRows(3) - J_am.bottomRows(3))* v / dt;
```

If this way of computing the dirft is not acceptable, maybe @jcarpent could give me some pointers to Pinocchio methods to achieve that properly ?