### PR TITLE
Fix Issue #70 - Missing coefficient when setting force reference

### DIFF
--- a/src/contacts/contact-point.cpp
+++ b/src/contacts/contact-point.cpp
@@ -106,7 +106,7 @@ void ContactPoint::updateForceRegularizationTask()
   Matrix3 A = Matrix3::Zero();
   A.diagonal() = m_weightForceRegTask;
   m_forceRegTask.setMatrix(A);
-  m_forceRegTask.setVector(m_fRef);
+  m_forceRegTask.setVector(A*m_fRef);
 }
 
 void ContactPoint:: updateForceGeneratorMatrix()


### PR DESCRIPTION
Dear all,

This PR is related to issue #70 that appeared when setting a non-zero force reference for a contact-point task. A coefficient was missing in the code and forced us to set the force reference to `w_reg_ref * F` instead of just `F` to get a proper convergence.