### PR TITLE
Refactor TrajectorySample::pos, vel, acc to value, derivative, second_derivative

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,7 @@ FILE(GLOB ${PYWRAP}_HEADERS
 
 SET(${PROJECT_NAME}_HEADERS
   include/tsid/config.hpp
+  include/tsid/macros.hpp
   include/tsid/deprecation.hpp
   include/tsid/utils/statistics.hpp
   include/tsid/utils/stop-watch.hpp

--- a/include/tsid/bindings/python/trajectories/trajectory-base.hpp
+++ b/include/tsid/bindings/python/trajectories/trajectory-base.hpp
@@ -83,7 +83,10 @@ namespace tsid
       }
       static void setvalue_se3(TrajSample & self, const pinocchio::SE3 & value){
         assert (self.getValue().size() == 12);
-        self.setValue(value);
+TSID_DISABLE_WARNING_PUSH
+TSID_DISABLE_WARNING_DEPRECATED
+        tsid::math::SE3ToVector(value, self.pos);
+TSID_DISABLE_WARNING_POP
       }
       static void setderivative(TrajSample & self, const Eigen::VectorXd derivative){
         assert (self.getDerivative().size() == derivative.size());

--- a/include/tsid/bindings/python/trajectories/trajectory-base.hpp
+++ b/include/tsid/bindings/python/trajectories/trajectory-base.hpp
@@ -20,8 +20,11 @@
 
 #include "tsid/bindings/python/fwd.hpp"
 
+
 #include <tsid/math/utils.hpp>
 #include "tsid/trajectories/trajectory-base.hpp"
+
+#include <pinocchio/bindings/python/utils/deprecation.hpp>
 #include <assert.h>
 namespace tsid
 {
@@ -56,14 +59,21 @@ namespace tsid
         .def("second_derivative", &TrajectorySamplePythonVisitor::setsecond_derivative)
 
         // Deprecated methods:
-        .def("pos", &TrajectorySamplePythonVisitor::value)
-        .def("vel", &TrajectorySamplePythonVisitor::derivative)
-        .def("acc", &TrajectorySamplePythonVisitor::second_derivative)
+        .def("pos", &TrajectorySamplePythonVisitor::value,
+            pinocchio::python::deprecated_function<>("This method is now deprecated. Please use .value"))
+        .def("vel", &TrajectorySamplePythonVisitor::derivative,
+            pinocchio::python::deprecated_function<>("This method is now deprecated. Please use .derivative"))
+        .def("acc", &TrajectorySamplePythonVisitor::second_derivative,
+            pinocchio::python::deprecated_function<>("This method is now deprecated. Please use .second_derivative"))
 
-        .def("pos", &TrajectorySamplePythonVisitor::setvalue_vec)
-        .def("pos", &TrajectorySamplePythonVisitor::setvalue_se3)
-        .def("vel", &TrajectorySamplePythonVisitor::setderivative)
-        .def("acc", &TrajectorySamplePythonVisitor::setsecond_derivative)
+        .def("pos", &TrajectorySamplePythonVisitor::setvalue_vec,
+            pinocchio::python::deprecated_function<>("This method is now deprecated. Please use .value"))
+        .def("pos", &TrajectorySamplePythonVisitor::setvalue_se3,
+            pinocchio::python::deprecated_function<>("This method is now deprecated. Please use .value"))
+        .def("vel", &TrajectorySamplePythonVisitor::setderivative,
+            pinocchio::python::deprecated_function<>("This method is now deprecated. Please use .derivative"))
+        .def("acc", &TrajectorySamplePythonVisitor::setsecond_derivative,
+            pinocchio::python::deprecated_function<>("This method is now deprecated. Please use .second_derivative"))
         ;
       }
 

--- a/include/tsid/bindings/python/trajectories/trajectory-base.hpp
+++ b/include/tsid/bindings/python/trajectories/trajectory-base.hpp
@@ -78,20 +78,20 @@ namespace tsid
       }
 
       static void setvalue_vec(TrajSample & self, const Eigen::VectorXd value){
-        assert (self.value.size() == value.size());
-        self.value = value;
+        assert (self.getValue().size() == value.size());
+        self.setValue(value);
       }
       static void setvalue_se3(TrajSample & self, const pinocchio::SE3 & value){
-        assert (self.value.size() == 12);
-        tsid::math::SE3ToVector(value, self.value);
+        assert (self.getValue().size() == 12);
+        self.setValue(value);
       }
       static void setderivative(TrajSample & self, const Eigen::VectorXd derivative){
-        assert (self.derivative.size() == derivative.size());
-        self.derivative = derivative;
+        assert (self.getDerivative().size() == derivative.size());
+        self.setDerivative(derivative);
       }
       static void setsecond_derivative(TrajSample & self, const Eigen::VectorXd second_derivative){
-        assert (self.second_derivative.size() == second_derivative.size());
-        self.second_derivative = second_derivative;
+        assert (self.getSecondDerivative().size() == second_derivative.size());
+        self.setSecondDerivative(second_derivative);
       }
       static void resize(TrajSample & self, const unsigned int & size){
           self.resize(size, size);
@@ -100,13 +100,13 @@ namespace tsid
           self.resize(value_size, derivative_size);
       }
       static Eigen::VectorXd value(const TrajSample & self){
-          return self.value;
+          return self.getValue();
       }
       static Eigen::VectorXd derivative(const TrajSample & self){
-          return self.derivative;
+          return self.getDerivative();
       }
       static Eigen::VectorXd second_derivative(const TrajSample & self){
-          return self.second_derivative;
+          return self.getSecondDerivative();
       }
 
       static void expose(const std::string & class_name)

--- a/include/tsid/bindings/python/trajectories/trajectory-base.hpp
+++ b/include/tsid/bindings/python/trajectories/trajectory-base.hpp
@@ -58,12 +58,12 @@ namespace tsid
       }
 
       static void setpos_vec(TrajSample & self, const Eigen::VectorXd pos){
-        assert (self.pos.size() == pos.size());
-        self.pos = pos;
+        assert (self.value.size() == pos.size());
+        self.value = pos;
       }
       static void setpos_se3(TrajSample & self, const pinocchio::SE3 & pos){
-        assert (self.pos.size() == 12);
-        tsid::math::SE3ToVector(pos, self.pos);
+        assert (self.value.size() == 12);
+        tsid::math::SE3ToVector(pos, self.value);
       }
       static void setvel(TrajSample & self, const Eigen::VectorXd vel){
         assert (self.vel.size() == vel.size());
@@ -80,7 +80,7 @@ namespace tsid
           self.resize(pos_size, vel_size);
       }
       static Eigen::VectorXd pos(const TrajSample & self){
-          return self.pos;
+          return self.value;
       }
       static Eigen::VectorXd vel(const TrajSample & self){
           return self.vel;

--- a/include/tsid/bindings/python/trajectories/trajectory-base.hpp
+++ b/include/tsid/bindings/python/trajectories/trajectory-base.hpp
@@ -41,52 +41,62 @@ namespace tsid
       {
         cl
         .def(bp::init<unsigned int>((bp::arg("size")), "Default Constructor with size"))
-        .def(bp::init<unsigned int, unsigned int>((bp::arg("pos_size"), bp::arg("vel_size")), "Default Constructor with pos and vel size"))
+        .def(bp::init<unsigned int, unsigned int>((bp::arg("value_size"), bp::arg("derivative_size")), "Default Constructor with value and derivative size"))
 
         .def("resize", &TrajectorySamplePythonVisitor::resize, bp::arg("size"))
-        .def("resize", &TrajectorySamplePythonVisitor::resize2, bp::args("pos_size", "vel_size"))
+        .def("resize", &TrajectorySamplePythonVisitor::resize2, bp::args("value_size", "derivative_size"))
 
-        .def("pos", &TrajectorySamplePythonVisitor::pos)
-        .def("vel", &TrajectorySamplePythonVisitor::vel)
-        .def("acc", &TrajectorySamplePythonVisitor::acc)
+        .def("value", &TrajectorySamplePythonVisitor::value)
+        .def("derivative", &TrajectorySamplePythonVisitor::derivative)
+        .def("second_derivative", &TrajectorySamplePythonVisitor::second_derivative)
 
-        .def("pos", &TrajectorySamplePythonVisitor::setpos_vec)
-        .def("pos", &TrajectorySamplePythonVisitor::setpos_se3)
-        .def("vel", &TrajectorySamplePythonVisitor::setvel)
-        .def("acc", &TrajectorySamplePythonVisitor::setacc)
+        .def("value", &TrajectorySamplePythonVisitor::setvalue_vec)
+        .def("value", &TrajectorySamplePythonVisitor::setvalue_se3)
+        .def("derivative", &TrajectorySamplePythonVisitor::setderivative)
+        .def("second_derivative", &TrajectorySamplePythonVisitor::setsecond_derivative)
+
+        // Deprecated methods:
+        .def("pos", &TrajectorySamplePythonVisitor::value)
+        .def("vel", &TrajectorySamplePythonVisitor::derivative)
+        .def("acc", &TrajectorySamplePythonVisitor::second_derivative)
+
+        .def("pos", &TrajectorySamplePythonVisitor::setvalue_vec)
+        .def("pos", &TrajectorySamplePythonVisitor::setvalue_se3)
+        .def("vel", &TrajectorySamplePythonVisitor::setderivative)
+        .def("acc", &TrajectorySamplePythonVisitor::setsecond_derivative)
         ;
       }
 
-      static void setpos_vec(TrajSample & self, const Eigen::VectorXd pos){
-        assert (self.value.size() == pos.size());
-        self.value = pos;
+      static void setvalue_vec(TrajSample & self, const Eigen::VectorXd value){
+        assert (self.value.size() == value.size());
+        self.value = value;
       }
-      static void setpos_se3(TrajSample & self, const pinocchio::SE3 & pos){
+      static void setvalue_se3(TrajSample & self, const pinocchio::SE3 & value){
         assert (self.value.size() == 12);
-        tsid::math::SE3ToVector(pos, self.value);
+        tsid::math::SE3ToVector(value, self.value);
       }
-      static void setvel(TrajSample & self, const Eigen::VectorXd vel){
-        assert (self.vel.size() == vel.size());
-        self.vel = vel;
+      static void setderivative(TrajSample & self, const Eigen::VectorXd derivative){
+        assert (self.derivative.size() == derivative.size());
+        self.derivative = derivative;
       }
-      static void setacc(TrajSample & self, const Eigen::VectorXd acc){
-        assert (self.acc.size() == acc.size());
-        self.acc = acc;
+      static void setsecond_derivative(TrajSample & self, const Eigen::VectorXd second_derivative){
+        assert (self.second_derivative.size() == second_derivative.size());
+        self.second_derivative = second_derivative;
       }
       static void resize(TrajSample & self, const unsigned int & size){
           self.resize(size, size);
       }
-      static void resize2(TrajSample & self, const unsigned int & pos_size, const unsigned int & vel_size){
-          self.resize(pos_size, vel_size);
+      static void resize2(TrajSample & self, const unsigned int & value_size, const unsigned int & derivative_size){
+          self.resize(value_size, derivative_size);
       }
-      static Eigen::VectorXd pos(const TrajSample & self){
+      static Eigen::VectorXd value(const TrajSample & self){
           return self.value;
       }
-      static Eigen::VectorXd vel(const TrajSample & self){
-          return self.vel;
+      static Eigen::VectorXd derivative(const TrajSample & self){
+          return self.derivative;
       }
-      static Eigen::VectorXd acc(const TrajSample & self){
-          return self.acc;
+      static Eigen::VectorXd second_derivative(const TrajSample & self){
+          return self.second_derivative;
       }
 
       static void expose(const std::string & class_name)

--- a/include/tsid/macros.hpp
+++ b/include/tsid/macros.hpp
@@ -1,0 +1,28 @@
+#ifndef __TSID_MACROS_HPP__
+#define __TSID_MACROS_HPP__
+
+// ref https://www.fluentcpp.com/2019/08/30/how-to-disable-a-warning-in-cpp/
+#if defined(_MSC_VER)
+
+#define TSID_DISABLE_WARNING_PUSH           __pragma(warning( push ))
+#define TSID_DISABLE_WARNING_POP            __pragma(warning( pop ))
+#define TSID_DISABLE_WARNING(warningNumber) __pragma(warning( disable : warningNumber ))
+#define TSID_DISABLE_WARNING_DEPRECATED     TSID_DISABLE_WARNING(4996)
+
+#elif defined(__GNUC__) || defined(__clang__)
+
+#define TSID_DO_PRAGMA(X) _Pragma(#X)
+#define TSID_DISABLE_WARNING_PUSH           TSID_DO_PRAGMA(GCC diagnostic push)
+#define TSID_DISABLE_WARNING_POP            TSID_DO_PRAGMA(GCC diagnostic pop)
+#define TSID_DISABLE_WARNING(warningName)   TSID_DO_PRAGMA(GCC diagnostic ignored #warningName)
+#define TSID_DISABLE_WARNING_DEPRECATED     TSID_DISABLE_WARNING(-Wdeprecated-declarations)
+
+#else
+
+#define TSID_DISABLE_WARNING_PUSH
+#define TSID_DISABLE_WARNING_POP
+#define TSID_DISABLE_WARNING_DEPRECATED
+
+#endif
+
+#endif

--- a/include/tsid/tasks/task-se3-equality.hpp
+++ b/include/tsid/tasks/task-se3-equality.hpp
@@ -58,6 +58,7 @@ namespace tsid
       const ConstraintBase & getConstraint() const;
 
       void setReference(TrajectorySample & ref);
+      void setReference(const SE3 & ref);
       const TrajectorySample & getReference() const;
 
       /** Return the desired task acceleration (after applying the specified mask).

--- a/include/tsid/trajectories/trajectory-base.hpp
+++ b/include/tsid/trajectories/trajectory-base.hpp
@@ -32,16 +32,16 @@ namespace tsid
     public:
       EIGEN_MAKE_ALIGNED_OPERATOR_NEW
       
-      math::Vector pos, vel, acc;
+      math::Vector value, derivative, second_derivative;
 
       TrajectorySample(unsigned int size=0)
       {
         resize(size, size);
       }
 
-      TrajectorySample(unsigned int size_pos, unsigned int size_vel)
+      TrajectorySample(unsigned int size_value, unsigned int size_derivative)
       {
-        resize(size_pos, size_vel);
+        resize(size_value, size_derivative);
       }
 
       void resize(unsigned int size)
@@ -49,11 +49,11 @@ namespace tsid
         resize(size, size);
       }
 
-      void resize(unsigned int size_pos, unsigned int size_vel)
+      void resize(unsigned int size_value, unsigned int size_derivative)
       {
-        pos.setZero(size_pos);
-        vel.setZero(size_vel);
-        acc.setZero(size_vel);
+        value.setZero(size_value);
+        derivative.setZero(size_derivative);
+        second_derivative.setZero(size_derivative);
       }
     };
 

--- a/include/tsid/trajectories/trajectory-base.hpp
+++ b/include/tsid/trajectories/trajectory-base.hpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017 CNRS
+// Copyright (c) 2017-2021 CNRS
 //
 // This file is part of tsid
 // tsid is free software: you can redistribute it
@@ -18,7 +18,12 @@
 #ifndef __invdyn_trajectory_base_hpp__
 #define __invdyn_trajectory_base_hpp__
 
+#include <pinocchio/spatial/se3.hpp>
+
+#include "tsid/deprecation.hpp"
+#include "tsid/macros.hpp"
 #include "tsid/math/fwd.hpp"
+#include "tsid/math/utils.hpp"
 
 #include <string>
 
@@ -26,17 +31,62 @@ namespace tsid
 {
   namespace trajectories
   {
-    
+
+    typedef Eigen::Map<const Eigen::Matrix<double, 3, 3>> MapMatrix3;
+
     class TrajectorySample
     {
     public:
       EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-      
-      math::Vector value, derivative, second_derivative;
+
+      // TODO rename pos, vel, acc → value, derivative, second_derivative
+      DEPRECATED math::Vector pos, vel, acc;
+
+TSID_DISABLE_WARNING_PUSH
+TSID_DISABLE_WARNING_DEPRECATED
+      // getters / setters with updated names for math::Vector
+      const math::Vector & getValue() const { return pos; }
+      const math::Vector & getDerivative() const { return vel; }
+      const math::Vector & getSecondDerivative() const { return acc; }
+      void setValue(const math::Vector & value) { pos = value; }
+      void setDerivative(const math::Vector & derivative) { vel = derivative; }
+      void setSecondDerivative(const math::Vector & second_derivative) { acc = second_derivative; }
+
+      // getters / setters with updated names for pinocchio::SE3
+      void getValue(pinocchio::SE3 & value) const
+      {
+        assert(pos.size() == 12);
+        value.translation( pos.head<3>());
+        value.rotation(MapMatrix3(&pos(3), 3, 3));
+      }
+      void getDerivative(pinocchio::SE3 & derivative) const
+      {
+        assert(vel.size() == 12);
+        derivative.translation(vel.head<3>());
+        derivative.rotation(MapMatrix3(&vel(3), 3, 3));
+      }
+      void getSecondDerivative(pinocchio::SE3 & second_derivative) const
+      {
+        assert(acc.size() == 12);
+        second_derivative.translation(acc.head<3>());
+        second_derivative.rotation(MapMatrix3(&acc(3), 3, 3));
+      }
+      void setValue(const pinocchio::SE3 & value)
+      {
+        tsid::math::SE3ToVector(value, pos);
+      }
+      void setDerivative(const pinocchio::SE3 & derivative)
+      {
+        tsid::math::SE3ToVector(derivative, vel);
+      }
+      void setSecondDerivative(const pinocchio::SE3 & second_derivative)
+      {
+        tsid::math::SE3ToVector(second_derivative, acc);
+      }
 
       TrajectorySample(unsigned int size=0)
       {
-        resize(size, size);
+        resize(size);
       }
 
       TrajectorySample(unsigned int size_value, unsigned int size_derivative)
@@ -51,10 +101,17 @@ namespace tsid
 
       void resize(unsigned int size_value, unsigned int size_derivative)
       {
-        value.setZero(size_value);
-        derivative.setZero(size_derivative);
-        second_derivative.setZero(size_derivative);
+        pos.setZero(size_value);
+        vel.setZero(size_derivative);
+        acc.setZero(size_derivative);
       }
+
+      // declare default constructors / destructors to disable the deprecation
+      // message for them. TODO: Remove this after the
+      // pos/vel/acc → value/derivative/second_derivative rename
+      ~TrajectorySample() = default;
+      TrajectorySample(const TrajectorySample&) = default;
+TSID_DISABLE_WARNING_POP
     };
 
 

--- a/include/tsid/trajectories/trajectory-base.hpp
+++ b/include/tsid/trajectories/trajectory-base.hpp
@@ -18,8 +18,6 @@
 #ifndef __invdyn_trajectory_base_hpp__
 #define __invdyn_trajectory_base_hpp__
 
-#include <pinocchio/spatial/se3.hpp>
-
 #include "tsid/deprecation.hpp"
 #include "tsid/macros.hpp"
 #include "tsid/math/fwd.hpp"
@@ -51,38 +49,6 @@ TSID_DISABLE_WARNING_DEPRECATED
       void setValue(const math::Vector & value) { pos = value; }
       void setDerivative(const math::Vector & derivative) { vel = derivative; }
       void setSecondDerivative(const math::Vector & second_derivative) { acc = second_derivative; }
-
-      // getters / setters with updated names for pinocchio::SE3
-      void getValue(pinocchio::SE3 & value) const
-      {
-        assert(pos.size() == 12);
-        value.translation( pos.head<3>());
-        value.rotation(MapMatrix3(&pos(3), 3, 3));
-      }
-      void getDerivative(pinocchio::SE3 & derivative) const
-      {
-        assert(vel.size() == 12);
-        derivative.translation(vel.head<3>());
-        derivative.rotation(MapMatrix3(&vel(3), 3, 3));
-      }
-      void getSecondDerivative(pinocchio::SE3 & second_derivative) const
-      {
-        assert(acc.size() == 12);
-        second_derivative.translation(acc.head<3>());
-        second_derivative.rotation(MapMatrix3(&acc(3), 3, 3));
-      }
-      void setValue(const pinocchio::SE3 & value)
-      {
-        tsid::math::SE3ToVector(value, pos);
-      }
-      void setDerivative(const pinocchio::SE3 & derivative)
-      {
-        tsid::math::SE3ToVector(derivative, vel);
-      }
-      void setSecondDerivative(const pinocchio::SE3 & second_derivative)
-      {
-        tsid::math::SE3ToVector(second_derivative, acc);
-      }
 
       TrajectorySample(unsigned int size=0)
       {

--- a/src/contacts/contact-6d.cpp
+++ b/src/contacts/contact-6d.cpp
@@ -227,7 +227,7 @@ void Contact6d::setForceReference(ConstRefVector & f_ref)
 void Contact6d::setReference(const SE3 & ref)
 {
   TrajectorySample s(12, 6);
-  SE3ToVector(ref, s.pos);
+  SE3ToVector(ref, s.value);
   m_motionTask.setReference(s);
 }
 

--- a/src/contacts/contact-6d.cpp
+++ b/src/contacts/contact-6d.cpp
@@ -227,7 +227,7 @@ void Contact6d::setForceReference(ConstRefVector & f_ref)
 void Contact6d::setReference(const SE3 & ref)
 {
   TrajectorySample s(12, 6);
-  SE3ToVector(ref, s.value);
+  s.setValue(ref);
   m_motionTask.setReference(s);
 }
 

--- a/src/contacts/contact-6d.cpp
+++ b/src/contacts/contact-6d.cpp
@@ -226,9 +226,7 @@ void Contact6d::setForceReference(ConstRefVector & f_ref)
 
 void Contact6d::setReference(const SE3 & ref)
 {
-  TrajectorySample s(12, 6);
-  s.setValue(ref);
-  m_motionTask.setReference(s);
+  m_motionTask.setReference(ref);
 }
 
 const ConstraintBase & Contact6d::computeMotionTask(const double t,

--- a/src/contacts/contact-point.cpp
+++ b/src/contacts/contact-point.cpp
@@ -203,7 +203,7 @@ void ContactPoint::setForceReference(ConstRefVector & f_ref)
 void ContactPoint::setReference(const SE3 & ref)
 {
   TrajectorySample s(12, 6);
-  SE3ToVector(ref, s.pos);
+  SE3ToVector(ref, s.value);
   m_motionTask.setReference(s);
 }
 

--- a/src/contacts/contact-point.cpp
+++ b/src/contacts/contact-point.cpp
@@ -202,9 +202,7 @@ void ContactPoint::setForceReference(ConstRefVector & f_ref)
 
 void ContactPoint::setReference(const SE3 & ref)
 {
-  TrajectorySample s(12, 6);
-  s.setValue(ref);
-  m_motionTask.setReference(s);
+  m_motionTask.setReference(ref);
 }
 
 const ConstraintBase & ContactPoint::computeMotionTask(const double t,

--- a/src/contacts/contact-point.cpp
+++ b/src/contacts/contact-point.cpp
@@ -124,16 +124,16 @@ void ContactPoint:: updateForceGeneratorMatrix()
 unsigned int ContactPoint::n_motion() const { return m_motionTask.dim(); }
 unsigned int ContactPoint::n_force() const { return 3; }
 
-const Vector & ContactPoint::Kp() 
-{ 
-  m_Kp3 = m_motionTask.Kp().head<3>(); 
-  return m_Kp3; 
+const Vector & ContactPoint::Kp()
+{
+  m_Kp3 = m_motionTask.Kp().head<3>();
+  return m_Kp3;
 }
 
-const Vector & ContactPoint::Kd() 
-{ 
-  m_Kd3 = m_motionTask.Kd().head<3>(); 
-  return m_Kd3; 
+const Vector & ContactPoint::Kd()
+{
+  m_Kd3 = m_motionTask.Kd().head<3>();
+  return m_Kd3;
 }
 
 void ContactPoint::Kp(ConstRefVector Kp)
@@ -203,7 +203,7 @@ void ContactPoint::setForceReference(ConstRefVector & f_ref)
 void ContactPoint::setReference(const SE3 & ref)
 {
   TrajectorySample s(12, 6);
-  SE3ToVector(ref, s.value);
+  s.setValue(ref);
   m_motionTask.setReference(s);
 }
 

--- a/src/tasks/task-angular-momentum-equality.cpp
+++ b/src/tasks/task-angular-momentum-equality.cpp
@@ -101,7 +101,7 @@ namespace tsid
 
     const Vector & TaskAMEquality::dmomentum_ref() const
     {
-      return m_ref.getSecondDerivative();
+      return m_ref.getDerivative();
     }
 
     const ConstraintBase & TaskAMEquality::getConstraint() const
@@ -121,7 +121,7 @@ namespace tsid
       m_L_error = m_L - m_ref.getValue();
 
       m_dL_des = - m_Kp.cwiseProduct(m_L_error)
-                + m_ref.getSecondDerivative();
+                + m_ref.getDerivative();
 
 #ifndef NDEBUG
 //      std::cout<<m_name<<" errors: "<<m_L_error.norm()<<" "

--- a/src/tasks/task-angular-momentum-equality.cpp
+++ b/src/tasks/task-angular-momentum-equality.cpp
@@ -96,12 +96,12 @@ namespace tsid
     }
     const Vector & TaskAMEquality::momentum_ref() const
     {
-      return m_ref.vel;
+      return m_ref.derivative;
     }
 
     const Vector & TaskAMEquality::dmomentum_ref() const
     {
-      return m_ref.acc;
+      return m_ref.second_derivative;
     }
 
     const ConstraintBase & TaskAMEquality::getConstraint() const
@@ -118,10 +118,10 @@ namespace tsid
       // Get momentum jacobian
       const Matrix6x & J_am = m_robot.momentumJacobian(data);
       m_L = J_am.bottomRows(3) * v;
-      m_L_error = m_L - m_ref.vel;
+      m_L_error = m_L - m_ref.derivative;
 
       m_dL_des = - m_Kp.cwiseProduct(m_L_error)
-                + m_ref.acc;
+                + m_ref.second_derivative;
 
 #ifndef NDEBUG
 //      std::cout<<m_name<<" errors: "<<m_L_error.norm()<<" "

--- a/src/tasks/task-angular-momentum-equality.cpp
+++ b/src/tasks/task-angular-momentum-equality.cpp
@@ -96,12 +96,12 @@ namespace tsid
     }
     const Vector & TaskAMEquality::momentum_ref() const
     {
-      return m_ref.derivative;
+      return m_ref.value;
     }
 
     const Vector & TaskAMEquality::dmomentum_ref() const
     {
-      return m_ref.second_derivative;
+      return m_ref.derivative;
     }
 
     const ConstraintBase & TaskAMEquality::getConstraint() const
@@ -118,10 +118,10 @@ namespace tsid
       // Get momentum jacobian
       const Matrix6x & J_am = m_robot.momentumJacobian(data);
       m_L = J_am.bottomRows(3) * v;
-      m_L_error = m_L - m_ref.derivative;
+      m_L_error = m_L - m_ref.value;
 
       m_dL_des = - m_Kp.cwiseProduct(m_L_error)
-                + m_ref.second_derivative;
+                + m_ref.derivative;
 
 #ifndef NDEBUG
 //      std::cout<<m_name<<" errors: "<<m_L_error.norm()<<" "

--- a/src/tasks/task-angular-momentum-equality.cpp
+++ b/src/tasks/task-angular-momentum-equality.cpp
@@ -96,12 +96,12 @@ namespace tsid
     }
     const Vector & TaskAMEquality::momentum_ref() const
     {
-      return m_ref.value;
+      return m_ref.getValue();
     }
 
     const Vector & TaskAMEquality::dmomentum_ref() const
     {
-      return m_ref.derivative;
+      return m_ref.getSecondDerivative();
     }
 
     const ConstraintBase & TaskAMEquality::getConstraint() const
@@ -118,10 +118,10 @@ namespace tsid
       // Get momentum jacobian
       const Matrix6x & J_am = m_robot.momentumJacobian(data);
       m_L = J_am.bottomRows(3) * v;
-      m_L_error = m_L - m_ref.value;
+      m_L_error = m_L - m_ref.getValue();
 
       m_dL_des = - m_Kp.cwiseProduct(m_L_error)
-                + m_ref.derivative;
+                + m_ref.getSecondDerivative();
 
 #ifndef NDEBUG
 //      std::cout<<m_name<<" errors: "<<m_L_error.norm()<<" "
@@ -134,6 +134,6 @@ namespace tsid
 
       return m_constraint;
     }
-    
+
   }
 }

--- a/src/tasks/task-com-equality.cpp
+++ b/src/tasks/task-com-equality.cpp
@@ -120,12 +120,12 @@ namespace tsid
 
     const Vector & TaskComEquality::position_ref() const
     {
-      return m_ref.pos;
+      return m_ref.value;
     }
 
     const Vector & TaskComEquality::velocity_ref() const
     {
-      return m_ref.vel;
+      return m_ref.derivative;
     }
 
     const ConstraintBase & TaskComEquality::getConstraint() const
@@ -141,11 +141,11 @@ namespace tsid
       m_robot.com(data, m_p_com, m_v_com, m_drift);
 
       // Compute errors
-      m_p_error = m_p_com - m_ref.pos;
-      m_v_error = m_v_com - m_ref.vel;
+      m_p_error = m_p_com - m_ref.value;
+      m_v_error = m_v_com - m_ref.derivative;
       m_a_des = - m_Kp.cwiseProduct(m_p_error)
                 - m_Kd.cwiseProduct(m_v_error)
-                + m_ref.acc;
+                + m_ref.second_derivative;
 
       m_p_error_vec = m_p_error;
       m_v_error_vec = m_v_error;

--- a/src/tasks/task-com-equality.cpp
+++ b/src/tasks/task-com-equality.cpp
@@ -41,7 +41,7 @@ namespace tsid
       m_ref.resize(3);
       m_mask.resize(3);
       m_mask.fill(1.);
-      setMask(m_mask);      
+      setMask(m_mask);
     }
 
 
@@ -120,12 +120,12 @@ namespace tsid
 
     const Vector & TaskComEquality::position_ref() const
     {
-      return m_ref.value;
+      return m_ref.getValue();
     }
 
     const Vector & TaskComEquality::velocity_ref() const
     {
-      return m_ref.derivative;
+      return m_ref.getDerivative();
     }
 
     const ConstraintBase & TaskComEquality::getConstraint() const
@@ -141,11 +141,11 @@ namespace tsid
       m_robot.com(data, m_p_com, m_v_com, m_drift);
 
       // Compute errors
-      m_p_error = m_p_com - m_ref.value;
-      m_v_error = m_v_com - m_ref.derivative;
+      m_p_error = m_p_com - m_ref.getValue();
+      m_v_error = m_v_com - m_ref.getDerivative();
       m_a_des = - m_Kp.cwiseProduct(m_p_error)
                 - m_Kd.cwiseProduct(m_v_error)
-                + m_ref.second_derivative;
+                + m_ref.getSecondDerivative();
 
       m_p_error_vec = m_p_error;
       m_v_error_vec = m_v_error;
@@ -164,7 +164,7 @@ namespace tsid
 
         m_constraint.matrix().row(idx) = Jcom.row(i);
         m_constraint.vector().row(idx) = (m_a_des - m_drift).row(i);
-       
+
         m_a_des_masked(idx)            = m_a_des(i);
         m_drift_masked(idx)            = m_drift(i);
         m_p_error_masked_vec(idx)      = m_p_error_vec(i);

--- a/src/tasks/task-joint-posture.cpp
+++ b/src/tasks/task-joint-posture.cpp
@@ -92,9 +92,9 @@ namespace tsid
 
     void TaskJointPosture::setReference(const TrajectorySample & ref)
     {
-      assert(ref.pos.size()==m_robot.na());
-      assert(ref.vel.size()==m_robot.na());
-      assert(ref.acc.size()==m_robot.na());
+      assert(ref.value.size()==m_robot.na());
+      assert(ref.derivative.size()==m_robot.na());
+      assert(ref.second_derivative.size()==m_robot.na());
       m_ref = ref;
     }
 
@@ -135,12 +135,12 @@ namespace tsid
 
     const Vector & TaskJointPosture::position_ref() const
     {
-      return m_ref.pos;
+      return m_ref.value;
     }
 
     const Vector & TaskJointPosture::velocity_ref() const
     {
-      return m_ref.vel;
+      return m_ref.derivative;
     }
 
     const ConstraintBase & TaskJointPosture::getConstraint() const
@@ -156,11 +156,11 @@ namespace tsid
       // Compute errors
       m_p = q.tail(m_robot.na());
       m_v = v.tail(m_robot.na());
-      m_p_error = m_p - m_ref.pos;
-      m_v_error = m_v - m_ref.vel;
+      m_p_error = m_p - m_ref.value;
+      m_v_error = m_v - m_ref.derivative;
       m_a_des = - m_Kp.cwiseProduct(m_p_error)
                 - m_Kd.cwiseProduct(m_v_error)
-                + m_ref.acc;
+                + m_ref.second_derivative;
 
       for(unsigned int i=0; i<m_activeAxes.size(); i++)
         m_constraint.vector()(i) = m_a_des(m_activeAxes(i));

--- a/src/tasks/task-joint-posture.cpp
+++ b/src/tasks/task-joint-posture.cpp
@@ -92,9 +92,9 @@ namespace tsid
 
     void TaskJointPosture::setReference(const TrajectorySample & ref)
     {
-      assert(ref.value.size()==m_robot.na());
-      assert(ref.derivative.size()==m_robot.na());
-      assert(ref.second_derivative.size()==m_robot.na());
+      assert(ref.getValue().size()==m_robot.na());
+      assert(ref.getDerivative().size()==m_robot.na());
+      assert(ref.getSecondDerivative().size()==m_robot.na());
       m_ref = ref;
     }
 
@@ -135,12 +135,12 @@ namespace tsid
 
     const Vector & TaskJointPosture::position_ref() const
     {
-      return m_ref.value;
+      return m_ref.getValue();
     }
 
     const Vector & TaskJointPosture::velocity_ref() const
     {
-      return m_ref.derivative;
+      return m_ref.getDerivative();
     }
 
     const ConstraintBase & TaskJointPosture::getConstraint() const
@@ -156,16 +156,16 @@ namespace tsid
       // Compute errors
       m_p = q.tail(m_robot.na());
       m_v = v.tail(m_robot.na());
-      m_p_error = m_p - m_ref.value;
-      m_v_error = m_v - m_ref.derivative;
+      m_p_error = m_p - m_ref.getValue();
+      m_v_error = m_v - m_ref.getDerivative();
       m_a_des = - m_Kp.cwiseProduct(m_p_error)
                 - m_Kd.cwiseProduct(m_v_error)
-                + m_ref.second_derivative;
+                + m_ref.getSecondDerivative();
 
       for(unsigned int i=0; i<m_activeAxes.size(); i++)
         m_constraint.vector()(i) = m_a_des(m_activeAxes(i));
       return m_constraint;
     }
-    
+
   }
 }

--- a/src/tasks/task-se3-equality.cpp
+++ b/src/tasks/task-se3-equality.cpp
@@ -97,9 +97,9 @@ namespace tsid
     void TaskSE3Equality::setReference(TrajectorySample & ref)
     {
       m_ref = ref;
-      vectorToSE3(ref.pos, m_M_ref);
-      m_v_ref = Motion(ref.vel);
-      m_a_ref = Motion(ref.acc);
+      vectorToSE3(ref.value, m_M_ref);
+      m_v_ref = Motion(ref.derivative);
+      m_a_ref = Motion(ref.second_derivative);
     }
 
     const TrajectorySample & TaskSE3Equality::getReference() const

--- a/src/tasks/task-se3-equality.cpp
+++ b/src/tasks/task-se3-equality.cpp
@@ -97,9 +97,9 @@ namespace tsid
     void TaskSE3Equality::setReference(TrajectorySample & ref)
     {
       m_ref = ref;
-      vectorToSE3(ref.value, m_M_ref);
-      m_v_ref = Motion(ref.derivative);
-      m_a_ref = Motion(ref.second_derivative);
+      ref.getValue(m_M_ref);
+      m_v_ref = Motion(ref.getDerivative());
+      m_a_ref = Motion(ref.getSecondDerivative());
     }
 
     const TrajectorySample & TaskSE3Equality::getReference() const
@@ -230,7 +230,7 @@ namespace tsid
 
         idx += 1;
       }
-      
+
       return m_constraint;
     }
   }

--- a/src/tasks/task-se3-equality.cpp
+++ b/src/tasks/task-se3-equality.cpp
@@ -97,10 +97,26 @@ namespace tsid
     void TaskSE3Equality::setReference(TrajectorySample & ref)
     {
       m_ref = ref;
-      ref.getValue(m_M_ref);
+TSID_DISABLE_WARNING_PUSH
+TSID_DISABLE_WARNING_DEPRECATED
+      assert(ref.pos.size() == 12);
+      m_M_ref.translation( ref.pos.head<3>());
+      m_M_ref.rotation(MapMatrix3(&ref.pos(3), 3, 3));
+TSID_DISABLE_WARNING_POP
       m_v_ref = Motion(ref.getDerivative());
       m_a_ref = Motion(ref.getSecondDerivative());
     }
+
+    void TaskSE3Equality::setReference(const SE3 & ref)
+    {
+      TrajectorySample s(12, 6);
+TSID_DISABLE_WARNING_PUSH
+TSID_DISABLE_WARNING_DEPRECATED
+      tsid::math::SE3ToVector(ref, s.pos);
+TSID_DISABLE_WARNING_POP
+      setReference(s);
+    }
+
 
     const TrajectorySample & TaskSE3Equality::getReference() const
     {

--- a/src/trajectories/trajectory-euclidian.cpp
+++ b/src/trajectories/trajectory-euclidian.cpp
@@ -35,14 +35,14 @@ namespace tsid
 
     void TrajectoryEuclidianConstant::setReference(ConstRefVector ref)
     {
-      m_sample.pos = ref;
-      m_sample.vel.setZero(ref.size());
-      m_sample.acc.setZero(ref.size());
+      m_sample.value = ref;
+      m_sample.derivative.setZero(ref.size());
+      m_sample.second_derivative.setZero(ref.size());
     }
 
     unsigned int TrajectoryEuclidianConstant::size() const
     {
-      return (unsigned int)m_sample.pos.size();
+      return (unsigned int)m_sample.value.size();
     }
 
     const TrajectorySample & TrajectoryEuclidianConstant::operator()(double )

--- a/src/trajectories/trajectory-euclidian.cpp
+++ b/src/trajectories/trajectory-euclidian.cpp
@@ -35,14 +35,13 @@ namespace tsid
 
     void TrajectoryEuclidianConstant::setReference(ConstRefVector ref)
     {
-      m_sample.value = ref;
-      m_sample.derivative.setZero(ref.size());
-      m_sample.second_derivative.setZero(ref.size());
+      m_sample.resize((unsigned int)ref.size());
+      m_sample.setValue(ref);
     }
 
     unsigned int TrajectoryEuclidianConstant::size() const
     {
-      return (unsigned int)m_sample.value.size();
+      return (unsigned int)m_sample.getValue().size();
     }
 
     const TrajectorySample & TrajectoryEuclidianConstant::operator()(double )

--- a/src/trajectories/trajectory-se3.cpp
+++ b/src/trajectories/trajectory-se3.cpp
@@ -36,7 +36,7 @@ namespace tsid
       :TrajectoryBase(name)
     {
       m_sample.resize(12, 6);
-      SE3ToVector(M, m_sample.pos);
+      SE3ToVector(M, m_sample.value);
     }
 
     unsigned int TrajectorySE3Constant::size() const
@@ -47,7 +47,7 @@ namespace tsid
     void TrajectorySE3Constant::setReference(const pinocchio::SE3 & ref)
     {
       m_sample.resize(12, 6);
-      SE3ToVector(ref, m_sample.pos);
+      SE3ToVector(ref, m_sample.value);
     }
 
     const TrajectorySample & TrajectorySE3Constant::operator()(double )

--- a/src/trajectories/trajectory-se3.cpp
+++ b/src/trajectories/trajectory-se3.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017 CNRS
+// Copyright (c) 2017-2021 CNRS
 //
 // This file is part of tsid
 // tsid is free software: you can redistribute it
@@ -36,7 +36,10 @@ namespace tsid
       :TrajectoryBase(name)
     {
       m_sample.resize(12, 6);
-      m_sample.setValue(M);
+TSID_DISABLE_WARNING_PUSH
+TSID_DISABLE_WARNING_DEPRECATED
+      tsid::math::SE3ToVector(M, m_sample.pos);
+TSID_DISABLE_WARNING_POP
     }
 
     unsigned int TrajectorySE3Constant::size() const
@@ -47,7 +50,10 @@ namespace tsid
     void TrajectorySE3Constant::setReference(const pinocchio::SE3 & ref)
     {
       m_sample.resize(12, 6);
-      m_sample.setValue(ref);
+TSID_DISABLE_WARNING_PUSH
+TSID_DISABLE_WARNING_DEPRECATED
+      tsid::math::SE3ToVector(ref, m_sample.pos);
+TSID_DISABLE_WARNING_POP
     }
 
     const TrajectorySample & TrajectorySE3Constant::operator()(double )

--- a/src/trajectories/trajectory-se3.cpp
+++ b/src/trajectories/trajectory-se3.cpp
@@ -36,7 +36,7 @@ namespace tsid
       :TrajectoryBase(name)
     {
       m_sample.resize(12, 6);
-      SE3ToVector(M, m_sample.value);
+      m_sample.setValue(M);
     }
 
     unsigned int TrajectorySE3Constant::size() const
@@ -47,7 +47,7 @@ namespace tsid
     void TrajectorySE3Constant::setReference(const pinocchio::SE3 & ref)
     {
       m_sample.resize(12, 6);
-      SE3ToVector(ref, m_sample.value);
+      m_sample.setValue(ref);
     }
 
     const TrajectorySample & TrajectorySE3Constant::operator()(double )

--- a/tests/python/CMakeLists.txt
+++ b/tests/python/CMakeLists.txt
@@ -8,6 +8,7 @@ SET(${PYWRAP}_TESTS
   #Solvers
   Tasks
   Trajectories
+  Deprecations
   )
 
 FOREACH(test ${${PYWRAP}_TESTS})

--- a/tests/python/test_Deprecations.py
+++ b/tests/python/test_Deprecations.py
@@ -1,0 +1,21 @@
+import unittest
+
+import numpy as np
+
+import tsid
+
+
+class DeprecationTest(unittest.TestCase):
+    def test_trajectory(self):
+        q_ref = np.ones(5)
+        traj_euclidian = tsid.TrajectoryEuclidianConstant("traj_eucl", q_ref)
+        with self.assertWarns(UserWarning):
+            traj_euclidian.computeNext().pos()
+        with self.assertWarns(UserWarning):
+            traj_euclidian.computeNext().vel()
+        with self.assertWarns(UserWarning):
+            traj_euclidian.computeNext().acc()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/python/test_Deprecations.py
+++ b/tests/python/test_Deprecations.py
@@ -1,4 +1,6 @@
 import unittest
+import sys
+import warnings
 
 import numpy as np
 
@@ -9,12 +11,29 @@ class DeprecationTest(unittest.TestCase):
     def test_trajectory(self):
         q_ref = np.ones(5)
         traj_euclidian = tsid.TrajectoryEuclidianConstant("traj_eucl", q_ref)
-        with self.assertWarns(UserWarning):
-            traj_euclidian.computeNext().pos()
-        with self.assertWarns(UserWarning):
-            traj_euclidian.computeNext().vel()
-        with self.assertWarns(UserWarning):
-            traj_euclidian.computeNext().acc()
+
+        if sys.version_info >= (3, 2):
+            with self.assertWarns(UserWarning):
+                traj_euclidian.computeNext().pos()
+            with self.assertWarns(UserWarning):
+                traj_euclidian.computeNext().vel()
+            with self.assertWarns(UserWarning):
+                traj_euclidian.computeNext().acc()
+        else:
+            with warnings.catch_warnings(record=True) as w:
+                self.assertEqual(len(w), 0)
+
+                traj_euclidian.computeNext().pos()
+                self.assertEqual(len(w), 1)
+                self.assertEqual(w[-1].category, UserWarning)
+
+                traj_euclidian.computeNext().vel()
+                self.assertEqual(len(w), 2)
+                self.assertEqual(w[-1].category, UserWarning)
+
+                traj_euclidian.computeNext().acc()
+                self.assertEqual(len(w), 3)
+                self.assertEqual(w[-1].category, UserWarning)
 
 
 if __name__ == '__main__':

--- a/tests/python/test_Formulation.py
+++ b/tests/python/test_Formulation.py
@@ -103,7 +103,7 @@ H_rf_ref_vec = np.matrix(np.zeros(12)).transpose()
 H_rf_ref_vec[0:3] = H_rf_ref.translation
 for i in range(0, 3):
     H_rf_ref_vec[3 * i + 3:3 * i + 6] = H_rf_ref.rotation[:, i]
-s.pos(H_rf_ref_vec)
+s.value(H_rf_ref_vec)
 rightFootTask.setReference(s)
 
 com_ref = robot.com(data)

--- a/tests/python/test_Trajectories.py
+++ b/tests/python/test_Trajectories.py
@@ -16,14 +16,14 @@ zero = np.matrix(np.zeros(n)).transpose()
 
 traj_euclidian = tsid.TrajectoryEuclidianConstant("traj_eucl", q_ref)
 assert traj_euclidian.has_trajectory_ended()
-assert np.linalg.norm(traj_euclidian.computeNext().pos() - q_ref, 2) < tol
-assert np.linalg.norm(traj_euclidian.getSample(0.0).pos() - q_ref, 2) < tol
+assert np.linalg.norm(traj_euclidian.computeNext().value() - q_ref, 2) < tol
+assert np.linalg.norm(traj_euclidian.getSample(0.0).value() - q_ref, 2) < tol
 
 traj_sample = tsid.TrajectorySample(n)
 traj_euclidian.getLastSample(traj_sample)
-assert np.linalg.norm(traj_sample.pos() - q_ref, 2) < tol
-assert np.linalg.norm(traj_sample.vel() - zero, 2) < tol
-assert np.linalg.norm(traj_sample.acc() - zero, 2) < tol
+assert np.linalg.norm(traj_sample.value() - q_ref, 2) < tol
+assert np.linalg.norm(traj_sample.derivative() - zero, 2) < tol
+assert np.linalg.norm(traj_sample.second_derivative() - zero, 2) < tol
 
 print("")
 print("Test Trajectory SE3")
@@ -41,13 +41,13 @@ traj_se3 = tsid.TrajectorySE3Constant("traj_se3")
 traj_se3.setReference(M_ref)
 
 assert traj_se3.has_trajectory_ended()
-assert np.linalg.norm(traj_se3.computeNext().pos() - M_vec, 2) < tol
-assert np.linalg.norm(traj_se3.getSample(0.0).pos() - M_vec, 2) < tol
+assert np.linalg.norm(traj_se3.computeNext().value() - M_vec, 2) < tol
+assert np.linalg.norm(traj_se3.getSample(0.0).value() - M_vec, 2) < tol
 
 traj_sample = tsid.TrajectorySample(12, 6)
 traj_se3.getLastSample(traj_sample)
-assert np.linalg.norm(traj_sample.pos() - M_vec, 2) < tol
-assert np.linalg.norm(traj_sample.vel() - zero, 2) < tol
-assert np.linalg.norm(traj_sample.acc() - zero, 2) < tol
+assert np.linalg.norm(traj_sample.value() - M_vec, 2) < tol
+assert np.linalg.norm(traj_sample.derivative() - zero, 2) < tol
+assert np.linalg.norm(traj_sample.second_derivative() - zero, 2) < tol
 
 print("All test is done")

--- a/tests/trajectories.cpp
+++ b/tests/trajectories.cpp
@@ -42,14 +42,14 @@ BOOST_AUTO_TEST_CASE ( test_trajectory_se3 )
 
   TrajectoryBase *traj = new TrajectorySE3Constant("traj_se3", M_ref);
   BOOST_CHECK(traj->has_trajectory_ended());
-  BOOST_CHECK(traj->computeNext().pos.isApprox(M_vec));
-  BOOST_CHECK(traj->operator ()(0.0).pos.isApprox(M_vec));
+  BOOST_CHECK(traj->computeNext().value.isApprox(M_vec));
+  BOOST_CHECK(traj->operator ()(0.0).value.isApprox(M_vec));
 
   TrajectorySample sample(12, 6);
   traj->getLastSample(sample);
-  BOOST_CHECK(sample.pos.isApprox(M_vec));
-  BOOST_CHECK(sample.vel.isApprox(zero));
-  BOOST_CHECK(sample.acc.isApprox(zero));
+  BOOST_CHECK(sample.value.isApprox(M_vec));
+  BOOST_CHECK(sample.derivative.isApprox(zero));
+  BOOST_CHECK(sample.second_derivative.isApprox(zero));
 }
 
 BOOST_AUTO_TEST_CASE ( test_trajectory_euclidian )
@@ -65,14 +65,14 @@ BOOST_AUTO_TEST_CASE ( test_trajectory_euclidian )
   TrajectoryBase *traj = new TrajectoryEuclidianConstant("traj_eucl", q_ref);
 
   BOOST_CHECK(traj->has_trajectory_ended());
-  BOOST_CHECK(traj->computeNext().pos.isApprox(q_ref));
-  BOOST_CHECK(traj->operator ()(0.0).pos.isApprox(q_ref));
+  BOOST_CHECK(traj->computeNext().value.isApprox(q_ref));
+  BOOST_CHECK(traj->operator ()(0.0).value.isApprox(q_ref));
 
   TrajectorySample sample(n);
   traj->getLastSample(sample);
-  BOOST_CHECK(sample.pos.isApprox(q_ref));
-  BOOST_CHECK(sample.vel.isApprox(zero));
-  BOOST_CHECK(sample.acc.isApprox(zero));
+  BOOST_CHECK(sample.value.isApprox(q_ref));
+  BOOST_CHECK(sample.derivative.isApprox(zero));
+  BOOST_CHECK(sample.second_derivative.isApprox(zero));
 }
 
 

--- a/tests/trajectories.cpp
+++ b/tests/trajectories.cpp
@@ -42,14 +42,14 @@ BOOST_AUTO_TEST_CASE ( test_trajectory_se3 )
 
   TrajectoryBase *traj = new TrajectorySE3Constant("traj_se3", M_ref);
   BOOST_CHECK(traj->has_trajectory_ended());
-  BOOST_CHECK(traj->computeNext().value.isApprox(M_vec));
-  BOOST_CHECK(traj->operator ()(0.0).value.isApprox(M_vec));
+  BOOST_CHECK(traj->computeNext().getValue().isApprox(M_vec));
+  BOOST_CHECK(traj->operator ()(0.0).getValue().isApprox(M_vec));
 
   TrajectorySample sample(12, 6);
   traj->getLastSample(sample);
-  BOOST_CHECK(sample.value.isApprox(M_vec));
-  BOOST_CHECK(sample.derivative.isApprox(zero));
-  BOOST_CHECK(sample.second_derivative.isApprox(zero));
+  BOOST_CHECK(sample.getValue().isApprox(M_vec));
+  BOOST_CHECK(sample.getDerivative().isApprox(zero));
+  BOOST_CHECK(sample.getSecondDerivative().isApprox(zero));
 }
 
 BOOST_AUTO_TEST_CASE ( test_trajectory_euclidian )
@@ -65,14 +65,14 @@ BOOST_AUTO_TEST_CASE ( test_trajectory_euclidian )
   TrajectoryBase *traj = new TrajectoryEuclidianConstant("traj_eucl", q_ref);
 
   BOOST_CHECK(traj->has_trajectory_ended());
-  BOOST_CHECK(traj->computeNext().value.isApprox(q_ref));
-  BOOST_CHECK(traj->operator ()(0.0).value.isApprox(q_ref));
+  BOOST_CHECK(traj->computeNext().getValue().isApprox(q_ref));
+  BOOST_CHECK(traj->operator ()(0.0).getValue().isApprox(q_ref));
 
   TrajectorySample sample(n);
   traj->getLastSample(sample);
-  BOOST_CHECK(sample.value.isApprox(q_ref));
-  BOOST_CHECK(sample.derivative.isApprox(zero));
-  BOOST_CHECK(sample.second_derivative.isApprox(zero));
+  BOOST_CHECK(sample.getValue().isApprox(q_ref));
+  BOOST_CHECK(sample.getDerivative().isApprox(zero));
+  BOOST_CHECK(sample.getSecondDerivative().isApprox(zero));
 }
 
 

--- a/tests/tsid-formulation.cpp
+++ b/tests/tsid-formulation.cpp
@@ -227,7 +227,7 @@ BOOST_AUTO_TEST_CASE ( test_invdyn_formulation_acc_force_remove_contact )
   tsid->addMotionTask(*rightFootTask, w_RF, 1);
 
   TrajectorySample s(12, 6);
-  SE3ToVector(H_rf_ref, s.pos);
+  SE3ToVector(H_rf_ref, s.value);
   rightFootTask->setReference(s);
 
   Vector3 com_ref = robot.com(tsid->data());

--- a/tests/tsid-formulation.cpp
+++ b/tests/tsid-formulation.cpp
@@ -114,11 +114,11 @@ class StandardRomeoInvDynCtrl
     package_dirs.push_back(romeo_model_path);
     const string urdfFileName = package_dirs[0] + "/urdf/romeo.urdf";
     robot = std::make_shared<RobotWrapper>(urdfFileName, package_dirs, pinocchio::JointModelFreeFlyer());
-    
+
     const string srdfFileName = package_dirs[0] + "/srdf/romeo_collision.srdf";
 
     pinocchio::srdf::loadReferenceConfigurations(robot->model(),srdfFileName,false);
-    
+
     const unsigned int nv = robot->nv();
     q = neutral(robot->model());
     std::cout << "q: " << q.transpose() << std::endl;
@@ -227,7 +227,7 @@ BOOST_AUTO_TEST_CASE ( test_invdyn_formulation_acc_force_remove_contact )
   tsid->addMotionTask(*rightFootTask, w_RF, 1);
 
   TrajectorySample s(12, 6);
-  SE3ToVector(H_rf_ref, s.value);
+  s.setValue(H_rf_ref);
   rightFootTask->setReference(s);
 
   Vector3 com_ref = robot.com(tsid->data());
@@ -642,7 +642,7 @@ BOOST_AUTO_TEST_CASE ( test_contact_point_invdyn_formulation_acc_force )
   }
 
   delete solver;
-  
+
   cout<<"\n### TEST FINISHED ###\n";
   PRINT_VECTOR(v);
   cout<<"Final   CoM position: "<<robot.com(tsid->data()).transpose()<<endl;

--- a/tests/tsid-formulation.cpp
+++ b/tests/tsid-formulation.cpp
@@ -226,9 +226,7 @@ BOOST_AUTO_TEST_CASE ( test_invdyn_formulation_acc_force_remove_contact )
                                      robot.model().getJointId(romeo_inv_dyn.rf_frame_name));
   tsid->addMotionTask(*rightFootTask, w_RF, 1);
 
-  TrajectorySample s(12, 6);
-  s.setValue(H_rf_ref);
-  rightFootTask->setReference(s);
+  rightFootTask->setReference(H_rf_ref);
 
   Vector3 com_ref = robot.com(tsid->data());
   com_ref(1) += 0.1;


### PR DESCRIPTION
Fix https://github.com/stack-of-tasks/tsid/issues/77

I did not find a good way to define "deprecated" methods with boost_python, so right now both API exist in python which is not really good. 

Feel free to add a commit in this PR or point me to a way to fix this. 