### PR TITLE
Fix warnings

### DIFF
--- a/include/tsid/tasks/task-joint-bounds.hpp
+++ b/include/tsid/tasks/task-joint-bounds.hpp
@@ -60,13 +60,13 @@ namespace tsid
 //      void mask(const Vector & mask);
 
     protected:
-      double m_dt;
-      int m_na, m_nv;
       Vector m_v_lb, m_v_ub;
       Vector m_a_lb, m_a_ub;
       Vector m_ddq_max_due_to_vel, m_ddq_min_due_to_vel;
 //      Vector m_mask;
       ConstraintBound m_constraint;
+      double m_dt;
+      int m_nv, m_na;
     };
 
   }


### PR DESCRIPTION
Try to fix this warrning by arranging the order of the variables called by the constructor :
```
In file included from tsid/src/tasks/task-joint-bounds.cpp:18:0:
tsid/include/tsid/tasks/task-joint-bounds.hpp: In constructor ‘tsid::tasks::TaskJointBounds::TaskJointBounds(const string&, tsid::tasks::TaskBase::RobotWrapper&, double)’:
tsid/include/tsid/tasks/task-joint-bounds.hpp:69:23: warning: ‘tsid::tasks::TaskJointBounds::m_constraint’ will be initialized after [-Wreorder]
       ConstraintBound m_constraint;
                       ^~~~~~~~~~~~
tsid/include/tsid/tasks/task-joint-bounds.hpp:63:14: warning:   ‘double tsid::tasks::TaskJointBounds::m_dt’ [-Wreorder]
       double m_dt;
              ^~~~
tsid/src/tasks/task-joint-bounds.cpp:29:5: warning:   when initialized here [-Wreorder]
     TaskJointBounds::TaskJointBounds(const std::string & name,
     ^~~~~~~~~~~~~~~
In file included from tsid/src/tasks/task-joint-bounds.cpp:18:0:
tsid/include/tsid/tasks/task-joint-bounds.hpp:64:17: warning: ‘tsid::tasks::TaskJointBounds::m_nv’ will be initialized after [-Wreorder]
       int m_na, m_nv;
                 ^~~~
tsid/include/tsid/tasks/task-joint-bounds.hpp:64:11: warning:   ‘int tsid::tasks::TaskJointBounds::m_na’ [-Wreorder]
       int m_na, m_nv;
           ^~~~
tsid/src/tasks/task-joint-bounds.cpp:29:5: warning:   when initialized here [-Wreorder]
     TaskJointBounds::TaskJointBounds(const std::string & name,
     ^~~~~~~~~~~~~~~
```