### PR TITLE
Fix warnings

### DIFF
--- a/include/tsid/tasks/task-capture-point-inequality.hpp
+++ b/include/tsid/tasks/task-capture-point-inequality.hpp
@@ -81,7 +81,7 @@ namespace tsid
       Vector m_support_limits_x;
       Vector m_support_limits_y;
 
-      double m_nv;
+      Eigen::Index m_nv;
       double m_delta_t;
       double m_g;
       double m_w;

--- a/include/tsid/tasks/task-motion.hpp
+++ b/include/tsid/tasks/task-motion.hpp
@@ -55,6 +55,7 @@ namespace tsid
     protected:
       math::Vector m_mask;
       math::Vector m_dummy;
+      trajectories::TrajectorySample TrajectorySample_dummy;
     };
   }
 }

--- a/src/robots/robot-wrapper.cpp
+++ b/src/robots/robot-wrapper.cpp
@@ -168,21 +168,21 @@ namespace tsid
     const SE3 & RobotWrapper::position(const Data & data,
                                        const Model::JointIndex index) const
     {
-      assert(index>=0 && index<data.oMi.size());
+      assert(index<data.oMi.size());
       return data.oMi[index];
     }
     
     const Motion & RobotWrapper::velocity(const Data & data,
                                           const Model::JointIndex index) const
     {
-      assert(index>=0 && index<data.v.size());
+      assert(index<data.v.size());
       return data.v[index];
     }
     
     const Motion & RobotWrapper::acceleration(const Data & data,
                                               const Model::JointIndex index) const
     {
-      assert(index>=0 && index<data.a.size());
+      assert(index<data.a.size());
       return data.a[index];
     }
     
@@ -190,7 +190,7 @@ namespace tsid
                                      const Model::JointIndex index,
                                      Data::Matrix6x & J) const
     {
-      assert(index>=0 && index<data.oMi.size());
+      assert(index<data.oMi.size());
       return pinocchio::getJointJacobian(m_model, data, index, pinocchio::WORLD, J);
     }
     
@@ -198,14 +198,14 @@ namespace tsid
                                      const Model::JointIndex index,
                                      Data::Matrix6x & J) const
     {
-      assert(index>=0 && index<data.oMi.size());
+      assert(index<data.oMi.size());
       return pinocchio::getJointJacobian(m_model, data, index, pinocchio::LOCAL, J);
     }
     
     SE3 RobotWrapper::framePosition(const Data & data,
                                     const Model::FrameIndex index) const
     {
-      assert(index>=0 && index<m_model.frames.size());
+      assert(index<m_model.frames.size());
       const Frame & f = m_model.frames[index];
       return data.oMi[f.parent].act(f.placement);
     }
@@ -214,7 +214,7 @@ namespace tsid
                                      const Model::FrameIndex index,
                                      SE3 & framePosition) const
     {
-      assert(index>=0 && index<m_model.frames.size());
+      assert(index<m_model.frames.size());
       const Frame & f = m_model.frames[index];
       framePosition = data.oMi[f.parent].act(f.placement);
     }
@@ -222,7 +222,7 @@ namespace tsid
     Motion RobotWrapper::frameVelocity(const Data & data,
                                        const Model::FrameIndex index) const
     {
-      assert(index>=0 && index<m_model.frames.size());
+      assert(index<m_model.frames.size());
       const Frame & f = m_model.frames[index];
       return f.placement.actInv(data.v[f.parent]);
     }
@@ -231,7 +231,7 @@ namespace tsid
                                      const Model::FrameIndex index,
                                      Motion & frameVelocity) const
     {
-      assert(index>=0 && index<m_model.frames.size());
+      assert(index<m_model.frames.size());
       const Frame & f = m_model.frames[index];
       frameVelocity = f.placement.actInv(data.v[f.parent]);
     }
@@ -251,7 +251,7 @@ namespace tsid
     Motion RobotWrapper::frameAcceleration(const Data & data,
                                            const Model::FrameIndex index) const
     {
-      assert(index>=0 && index<m_model.frames.size());
+      assert(index<m_model.frames.size());
       const Frame & f = m_model.frames[index];
       return f.placement.actInv(data.a[f.parent]);
     }
@@ -260,7 +260,7 @@ namespace tsid
                                          const Model::FrameIndex index,
                                          Motion & frameAcceleration) const
     {
-      assert(index>=0 && index<m_model.frames.size());
+      assert(index<m_model.frames.size());
       const Frame & f = m_model.frames[index];
       frameAcceleration = f.placement.actInv(data.a[f.parent]);
     }
@@ -280,7 +280,7 @@ namespace tsid
     Motion RobotWrapper::frameClassicAcceleration(const Data & data,
                                                   const Model::FrameIndex index) const
     {
-      assert(index>=0 && index<m_model.frames.size());
+      assert(index<m_model.frames.size());
       const Frame & f = m_model.frames[index];
       Motion a = f.placement.actInv(data.a[f.parent]);
       Motion v = f.placement.actInv(data.v[f.parent]);
@@ -292,7 +292,7 @@ namespace tsid
                                                 const Model::FrameIndex index,
                                                 Motion & frameAcceleration) const
     {
-      assert(index>=0 && index<m_model.frames.size());
+      assert(index<m_model.frames.size());
       const Frame & f = m_model.frames[index];
       frameAcceleration = f.placement.actInv(data.a[f.parent]);
       Motion v = f.placement.actInv(data.v[f.parent]);
@@ -315,7 +315,7 @@ namespace tsid
                                           const Model::FrameIndex index,
                                           Data::Matrix6x & J) const
     {
-      assert(index>=0 && index<m_model.frames.size());
+      assert(index<m_model.frames.size());
       return pinocchio::getFrameJacobian(m_model, data, index, pinocchio::WORLD, J);
     }
     
@@ -323,7 +323,7 @@ namespace tsid
                                           const Model::FrameIndex index,
                                           Data::Matrix6x & J) const
     {
-      assert(index>=0 && index<m_model.frames.size());
+      assert(index<m_model.frames.size());
       return pinocchio::getFrameJacobian(m_model, data, index, pinocchio::LOCAL, J);
     }
 

--- a/src/tasks/task-capture-point-inequality.cpp
+++ b/src/tasks/task-capture-point-inequality.cpp
@@ -100,9 +100,9 @@ namespace tsid
       m_safety_margin(1) = y_margin;
     }
 
-    const ConstraintBase & TaskCapturePointInequality::compute(const double t,
-                                                    ConstRefVector q,
-                                                    ConstRefVector v,
+    const ConstraintBase & TaskCapturePointInequality::compute(const double,
+                                                    ConstRefVector,
+                                                    ConstRefVector,
                                                     Data & data)
     {
       m_robot.com(data, m_p_com, m_v_com, m_drift);

--- a/src/tasks/task-motion.cpp
+++ b/src/tasks/task-motion.cpp
@@ -40,7 +40,7 @@ namespace tsid
       return m_mask.size() > 0;
     }
 
-    const TrajectorySample & TaskMotion::getReference() const { return TrajectorySample(); }
+    const TrajectorySample & TaskMotion::getReference() const { return TrajectorySample_dummy; }
 
     const Vector & TaskMotion::getDesiredAcceleration() const  { return m_dummy; }
 

--- a/tests/tasks.cpp
+++ b/tests/tasks.cpp
@@ -309,7 +309,7 @@ BOOST_AUTO_TEST_CASE ( test_task_joint_bounds )
   {
     robot.computeAllTerms(data, q, v);
     const ConstraintBase & constraint = task.compute(t, q, v, data);
-    BOOST_CHECK(constraint.rows()==robot.nv());
+    BOOST_CHECK(constraint.rows()==(Eigen::Index)robot.nv());
     BOOST_CHECK(static_cast<tsid::math::Index>(constraint.cols())==static_cast<tsid::math::Index>(robot.nv()));
     BOOST_REQUIRE(isFinite(constraint.lowerBound()));
     BOOST_REQUIRE(isFinite(constraint.upperBound()));
@@ -361,7 +361,7 @@ BOOST_AUTO_TEST_CASE ( test_task_joint_posVelAcc_bounds )
   {
     robot.computeAllTerms(data, q, v);
     const ConstraintBase & constraint = task.compute(t, q, v, data);
-    BOOST_CHECK(constraint.rows()==robot.na());
+    BOOST_CHECK(constraint.rows()==(Eigen::Index)robot.na());
     BOOST_CHECK(static_cast<tsid::math::Index>(constraint.cols())==static_cast<tsid::math::Index>(robot.nv()));
     BOOST_REQUIRE(isFinite(constraint.lowerBound()));
     BOOST_REQUIRE(isFinite(constraint.upperBound()));


### PR DESCRIPTION
Try to fix this warning :
`tsid/src/robots/robot-wrapper.cpp: In member function ‘const SE3& tsid::robots::RobotWrapper::position(const Data&, pinocchio::ModelTpl<double>::JointIndex) const’:
tsid/src/robots/robot-wrapper.cpp:171:19: warning: comparison of unsigned expression >= 0 is always true [-Wtype-limits]
       assert(index>=0 && index<data.oMi.size());
              ~~~~~^~~`
...
`tsid/src/robots/robot-wrapper.cpp: In member function ‘void tsid::robots::RobotWrapper::frameJacobianLocal(tsid::robots::RobotWrapper::Data&, pinocchio::ModelTpl<double>::FrameIndex, pinocchio::DataTpl<double>::Matrix6x&) const’:
tsid/src/robots/robot-wrapper.cpp:326:19: warning: comparison of unsigned expression >= 0 is always true [-Wtype-limits]
       assert(index>=0 && index<m_model.frames.size());
              ~~~~~^~~
`
