### PR TITLE
Choose floating-base (or not) when creating a robot wrapper

### DIFF
--- a/include/tsid/bindings/python/robots/robot-wrapper.hpp
+++ b/include/tsid/bindings/python/robots/robot-wrapper.hpp
@@ -41,7 +41,7 @@ namespace tsid
       {
         cl
         .def(bp::init<std::string, std_vec, bool>((bp::arg("filename"), bp::arg("package_dir"), bp::arg("verbose")), "Default constructor without RootJoint."))
-        .def(bp::init<pinocchio::Model, bool>((bp::arg("Pinocchio Model"), bp::arg("verbose")), "Default constructor from pinocchio model"))
+        .def(bp::init<pinocchio::Model, bool, bool>((bp::arg("Pinocchio Model"), bp::arg("verbose"), bp::arg("freeflyer_base")), "Default constructor from pinocchio model"))
         .def(bp::init<std::string, std_vec, pinocchio::JointModelVariant &, bool>((bp::arg("filename"), bp::arg("package_dir"), bp::arg("roottype"), bp::arg("verbose")), "Default constructor without RootJoint."))
         .def("__init__",bp::make_constructor(RobotPythonVisitor<Robot> ::makeClass))
         .add_property("nq", &Robot::nq)

--- a/include/tsid/bindings/python/robots/robot-wrapper.hpp
+++ b/include/tsid/bindings/python/robots/robot-wrapper.hpp
@@ -41,9 +41,11 @@ namespace tsid
       {
         cl
         .def(bp::init<std::string, std_vec, bool>((bp::arg("filename"), bp::arg("package_dir"), bp::arg("verbose")), "Default constructor without RootJoint."))
-        .def(bp::init<pinocchio::Model, bool, bool>((bp::arg("Pinocchio Model"), bp::arg("verbose"), bp::arg("freeflyer_base")), "Default constructor from pinocchio model"))
-        .def(bp::init<std::string, std_vec, pinocchio::JointModelVariant &, bool>((bp::arg("filename"), bp::arg("package_dir"), bp::arg("roottype"), bp::arg("verbose")), "Default constructor without RootJoint."))
+        .def(bp::init<std::string, std_vec, pinocchio::JointModelVariant &, bool>((bp::arg("filename"), bp::arg("package_dir"), bp::arg("roottype"), bp::arg("verbose")), "Default constructor with RootJoint."))
+        .def(bp::init<pinocchio::Model, bool>((bp::arg("Pinocchio Model"), bp::arg("verbose")), "Default constructor from pinocchio model without RootJoint."))
+        .def(bp::init<pinocchio::Model, pinocchio::JointModelVariant &, bool>((bp::arg("Pinocchio Model"), bp::arg("roottype"), bp::arg("verbose")), "Default constructor from pinocchio model with RootJoint."))
         .def("__init__",bp::make_constructor(RobotPythonVisitor<Robot> ::makeClass))
+        .def("__init__",bp::make_constructor(RobotPythonVisitor<Robot> ::makeClassFromModel))
         .add_property("nq", &Robot::nq)
         .add_property("nv", &Robot::nv)
         .add_property("na", &Robot::na)
@@ -89,6 +91,18 @@ namespace tsid
             bp::extract<pinocchio::JointModelFreeFlyer>(bpObject)();
         boost::shared_ptr<Robot> p(new tsid::robots::RobotWrapper(filename,
                                                                   stdvec,
+                                                                  root_joint,
+                                                                  verbose));
+        return p;
+      }
+
+      static boost::shared_ptr<Robot> makeClassFromModel(pinocchio::Model model,
+                                                bp::object & bpObject,
+                                                bool verbose)
+      {
+        pinocchio::JointModelFreeFlyer root_joint =
+            bp::extract<pinocchio::JointModelFreeFlyer>(bpObject)();
+        boost::shared_ptr<Robot> p(new tsid::robots::RobotWrapper(model,
                                                                   root_joint,
                                                                   verbose));
         return p;

--- a/include/tsid/bindings/python/robots/robot-wrapper.hpp
+++ b/include/tsid/bindings/python/robots/robot-wrapper.hpp
@@ -43,9 +43,8 @@ namespace tsid
         .def(bp::init<std::string, std_vec, bool>((bp::arg("filename"), bp::arg("package_dir"), bp::arg("verbose")), "Default constructor without RootJoint."))
         .def(bp::init<std::string, std_vec, pinocchio::JointModelVariant &, bool>((bp::arg("filename"), bp::arg("package_dir"), bp::arg("roottype"), bp::arg("verbose")), "Default constructor with RootJoint."))
         .def(bp::init<pinocchio::Model, bool>((bp::arg("Pinocchio Model"), bp::arg("verbose")), "Default constructor from pinocchio model without RootJoint."))
-        .def(bp::init<pinocchio::Model, pinocchio::JointModelVariant &, bool>((bp::arg("Pinocchio Model"), bp::arg("roottype"), bp::arg("verbose")), "Default constructor from pinocchio model with RootJoint."))
+        .def(bp::init<pinocchio::Model, robots::RobotWrapper::RootJointType, bool>((bp::arg("Pinocchio Model"), bp::arg("rootJoint"), bp::arg("verbose")), "Default constructor from pinocchio model with RootJoint."))
         .def("__init__",bp::make_constructor(RobotPythonVisitor<Robot> ::makeClass))
-        .def("__init__",bp::make_constructor(RobotPythonVisitor<Robot> ::makeClassFromModel))
         .add_property("nq", &Robot::nq)
         .add_property("nv", &Robot::nv)
         .add_property("na", &Robot::na)
@@ -91,18 +90,6 @@ namespace tsid
             bp::extract<pinocchio::JointModelFreeFlyer>(bpObject)();
         boost::shared_ptr<Robot> p(new tsid::robots::RobotWrapper(filename,
                                                                   stdvec,
-                                                                  root_joint,
-                                                                  verbose));
-        return p;
-      }
-
-      static boost::shared_ptr<Robot> makeClassFromModel(pinocchio::Model model,
-                                                bp::object & bpObject,
-                                                bool verbose)
-      {
-        pinocchio::JointModelFreeFlyer root_joint =
-            bp::extract<pinocchio::JointModelFreeFlyer>(bpObject)();
-        boost::shared_ptr<Robot> p(new tsid::robots::RobotWrapper(model,
                                                                   root_joint,
                                                                   verbose));
         return p;
@@ -193,6 +180,11 @@ namespace tsid
                           bp::no_init)
         .def(RobotPythonVisitor<Robot>());
         ;
+        bp::enum_<robots::RobotWrapper::RootJointType>("RootJointType")
+            .value("FIXED_BASE_SYSTEM", robots::RobotWrapper::FIXED_BASE_SYSTEM)
+            .value("FLOATING_BASE_SYSTEM", robots::RobotWrapper::FLOATING_BASE_SYSTEM)
+            .export_values()
+            ;
       }
     };
   }

--- a/include/tsid/robots/robot-wrapper.hpp
+++ b/include/tsid/robots/robot-wrapper.hpp
@@ -60,10 +60,15 @@ namespace tsid
                    const std::vector<std::string> & package_dirs,
                    bool verbose=false);
 
-      RobotWrapper(const Model & m, bool verbose=false, bool floating_base=true);
-
       RobotWrapper(const std::string & filename,
                    const std::vector<std::string> & package_dirs,
+                   const pinocchio::JointModelVariant & rootJoint,
+                   bool verbose=false);
+
+      RobotWrapper(const Model & m,
+                   bool verbose=false);
+
+      RobotWrapper(const Model & m,
                    const pinocchio::JointModelVariant & rootJoint,
                    bool verbose=false);
       

--- a/include/tsid/robots/robot-wrapper.hpp
+++ b/include/tsid/robots/robot-wrapper.hpp
@@ -18,6 +18,7 @@
 #ifndef __invdyn_robot_wrapper_hpp__
 #define __invdyn_robot_wrapper_hpp__
 
+#include "tsid/deprecated.hh"
 #include "tsid/math/fwd.hpp"
 #include "tsid/robots/fwd.hpp"
 
@@ -54,22 +55,28 @@ namespace tsid
       typedef math::Matrix3x Matrix3x;
       typedef math::RefVector RefVector;
       typedef math::ConstRefVector ConstRefVector;
-      
-      
-      RobotWrapper(const std::string & filename,
-                   const std::vector<std::string> & package_dirs,
-                   bool verbose=false);
+
+      /* Possible root joints */
+      typedef enum e_RootJointType
+      {
+        FIXED_BASE_SYSTEM=0,
+        FLOATING_BASE_SYSTEM=1,
+      } RootJointType;
 
       RobotWrapper(const std::string & filename,
-                   const std::vector<std::string> & package_dirs,
-                   const pinocchio::JointModelVariant & rootJoint,
-                   bool verbose=false);
+                                   const std::vector<std::string> & package_dirs,
+                                   bool verbose=false);
+
+      RobotWrapper(const std::string & filename,
+                                   const std::vector<std::string> & package_dirs,
+                                   const pinocchio::JointModelVariant & rootJoint,
+                                   bool verbose=false);
+
+      TSID_DEPRECATED RobotWrapper(const Model & m,
+                                   bool verbose=false);
 
       RobotWrapper(const Model & m,
-                   bool verbose=false);
-
-      RobotWrapper(const Model & m,
-                   const pinocchio::JointModelVariant & rootJoint,
+                   RootJointType rootJoint,
                    bool verbose=false);
       
       virtual int nq() const;

--- a/include/tsid/robots/robot-wrapper.hpp
+++ b/include/tsid/robots/robot-wrapper.hpp
@@ -60,7 +60,7 @@ namespace tsid
                    const std::vector<std::string> & package_dirs,
                    bool verbose=false);
 
-      RobotWrapper(const Model & m, bool verbose=false);
+      RobotWrapper(const Model & m, bool verbose=false, bool floating_base=true);
 
       RobotWrapper(const std::string & filename,
                    const std::vector<std::string> & package_dirs,

--- a/src/robots/robot-wrapper.cpp
+++ b/src/robots/robot-wrapper.cpp
@@ -60,7 +60,6 @@ namespace tsid
                                bool verbose)
       : m_verbose(verbose)
     {
-      std::cout<<"[RobotWrapper] Constructor RobotWrapper(const pinocchio::Model&, bool) is deprecated. You should use RobotWrapper(const pinocchio::Model&, const pinocchio::JointModelVariant&, bool) instead.\n";
       m_model = m;
       m_model_filename = "";
       m_na = m_model.nv-6;

--- a/src/robots/robot-wrapper.cpp
+++ b/src/robots/robot-wrapper.cpp
@@ -60,20 +60,29 @@ namespace tsid
                                bool verbose)
       : m_verbose(verbose)
     {
+      std::cout<<"[RobotWrapper] Constructor RobotWrapper(const pinocchio::Model&, bool) is deprecated. You should use RobotWrapper(const pinocchio::Model&, const pinocchio::JointModelVariant&, bool) instead.\n";
       m_model = m;
       m_model_filename = "";
-      m_na = m_model.nv;
+      m_na = m_model.nv-6;
       init();
     }
 
     RobotWrapper::RobotWrapper(const pinocchio::Model& m,
-                               const pinocchio::JointModelVariant & rootJoint,
+                               RootJointType rootJoint,
                                bool verbose)
       : m_verbose(verbose)
     {
       m_model = m;
       m_model_filename = "";
-      m_na = m_model.nv-6;
+      m_na = m_model.nv;
+      switch(rootJoint) {
+        case FIXED_BASE_SYSTEM:
+          break;
+        case FLOATING_BASE_SYSTEM:
+          m_na -= 6;
+        default:
+          break;
+      }
       init();
     }
 

--- a/src/robots/robot-wrapper.cpp
+++ b/src/robots/robot-wrapper.cpp
@@ -44,12 +44,15 @@ namespace tsid
       init();
     }
 
-    RobotWrapper::RobotWrapper(const pinocchio::Model& m, bool verbose)
+    RobotWrapper::RobotWrapper(const pinocchio::Model& m, bool verbose, bool floating_base)
       : m_verbose(verbose)
     {
       m_model = m;
       m_model_filename = "";
-      m_na = m_model.nv-6;  // for backward compatibility assume the robot has a floating base
+      m_na = m_model.nv;
+      if(floating_base) {
+        m_na -= 6;
+      }
       init();
     }
     

--- a/src/robots/robot-wrapper.cpp
+++ b/src/robots/robot-wrapper.cpp
@@ -44,18 +44,6 @@ namespace tsid
       init();
     }
 
-    RobotWrapper::RobotWrapper(const pinocchio::Model& m, bool verbose, bool floating_base)
-      : m_verbose(verbose)
-    {
-      m_model = m;
-      m_model_filename = "";
-      m_na = m_model.nv;
-      if(floating_base) {
-        m_na -= 6;
-      }
-      init();
-    }
-    
     RobotWrapper::RobotWrapper(const std::string & filename,
                                const std::vector<std::string> & ,
                                const pinocchio::JointModelVariant & rootJoint,
@@ -64,6 +52,27 @@ namespace tsid
     {
       pinocchio::urdf::buildModel(filename, rootJoint, m_model, m_verbose);
       m_model_filename = filename;
+      m_na = m_model.nv-6;
+      init();
+    }
+
+    RobotWrapper::RobotWrapper(const pinocchio::Model& m,
+                               bool verbose)
+      : m_verbose(verbose)
+    {
+      m_model = m;
+      m_model_filename = "";
+      m_na = m_model.nv;
+      init();
+    }
+
+    RobotWrapper::RobotWrapper(const pinocchio::Model& m,
+                               const pinocchio::JointModelVariant & rootJoint,
+                               bool verbose)
+      : m_verbose(verbose)
+    {
+      m_model = m;
+      m_model_filename = "";
       m_na = m_model.nv-6;
       init();
     }


### PR DESCRIPTION
(Following this discussion #152)

This PR replicates the behavior of `RobotWrapper::RobotWrapper(const std::string & filename, const std::vector<std::string> & , bool verbose)` and  `RobotWrapper::RobotWrapper(const std::string & filename, const std::vector<std::string> & , const pinocchio::JointModelVariant & rootJoint, bool verbose)`, in terms of root joint management, for the constructors based on a `pinocchio::Model`.

⚠️ **Warning** : This PR breaks backward compatibility, as now the basic constructor from a `pinocchio::Model` creates a robot without a FreeFlyer root joint...

If we want to ensure backward compatibility using this approach, then we will create sets of constructors that will have opposite default behavior. Thus it can be very confusing and source of error...

What are your opinions on this ?