### PR TITLE
Add support for proxqp and osqp solver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,7 @@ set(${PROJECT_NAME}_TRAJECTORIES_HEADERS
 set(${PROJECT_NAME}_SOLVERS_HEADERS
     include/tsid/solvers/fwd.hpp
     include/tsid/solvers/utils.hpp
+    include/tsid/solvers/solver-qpData.hpp
     include/tsid/solvers/solver-HQP-output.hpp
     include/tsid/solvers/solver-HQP-base.hpp
     include/tsid/solvers/solver-HQP-factory.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,8 @@ option(EIGEN_RUNTIME_NO_MALLOC
 option(EIGEN_NO_AUTOMATIC_RESIZING
        "If ON, it forbids automatic resizing of dynamics arrays and matrices"
        OFF)
-option(PROXQP_SUPPORT "Support using the proxqp solver" ON)
-option(OSQP_SUPPORT "Support using the osqp solver" ON)
+option(PROXQP_SUPPORT "Support using the proxqp solver" OFF)
+option(OSQP_SUPPORT "Support using the osqp solver" OFF)
 
 # Project configuration
 if(NOT INSTALL_PYTHON_INTERFACE_ONLY)
@@ -144,6 +144,7 @@ set(${PROJECT_NAME}_SOLVERS_HEADERS
     include/tsid/solvers/solver-HQP-eiquadprog-fast.hpp)
 
 if(PROXQP_SUPPORT)
+  find_package(proxsuite REQUIRED)
   list(APPEND ${PROJECT_NAME}_SOLVERS_HEADERS
        include/tsid/solvers/solver-proxqp.hpp)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ option(EIGEN_RUNTIME_NO_MALLOC
 option(EIGEN_NO_AUTOMATIC_RESIZING
        "If ON, it forbids automatic resizing of dynamics arrays and matrices"
        OFF)
+option(PROXQP_SUPPORT "Support using the proxqp solver" ON)
 
 # Project configuration
 if(NOT INSTALL_PYTHON_INTERFACE_ONLY)
@@ -141,6 +142,10 @@ set(${PROJECT_NAME}_SOLVERS_HEADERS
     include/tsid/solvers/solver-HQP-eiquadprog-rt.hxx
     include/tsid/solvers/solver-HQP-eiquadprog-fast.hpp)
 
+if(PROXQP_SUPPORT)
+  list(APPEND ${PROJECT_NAME}_SOLVERS_HEADERS
+       include/tsid/solvers/solver-proxqp.hpp)
+endif()
 if(qpmad_FOUND)
   list(APPEND ${PROJECT_NAME}_SOLVERS_HEADERS
        include/tsid/solvers/solver-HQP-qpmad.hpp)
@@ -220,6 +225,9 @@ set(${PROJECT_NAME}_SOLVERS_SOURCES
     src/solvers/solver-HQP-qpoases.cpp
     src/solvers/utils.cpp)
 
+if(PROXQP_SUPPORT)
+  list(APPEND ${PROJECT_NAME}_SOLVERS_SOURCES src/solvers/solver-proxqp.cpp)
+endif()
 if(qpmad_FOUND)
   list(APPEND ${PROJECT_NAME}_SOLVERS_SOURCES src/solvers/solver-HQP-qpmad.cpp)
 endif()
@@ -251,6 +259,10 @@ target_include_directories(${PROJECT_NAME} PUBLIC $<INSTALL_INTERFACE:include>)
 target_link_libraries(${PROJECT_NAME} PUBLIC pinocchio::pinocchio
                                              eiquadprog::eiquadprog)
 
+if(PROXQP_SUPPORT)
+  target_include_directories(${PROJECT_NAME} PUBLIC ${proxsuite_INCLUDE_DIRS})
+  target_compile_definitions(${PROJECT_NAME} PUBLIC -DTSID_PROXSUITE_FOUND)
+endif()
 if(qpmad_FOUND)
   target_include_directories(${PROJECT_NAME} PUBLIC ${qpmad_INCLUDE_DIRS})
   target_compile_definitions(${PROJECT_NAME} PUBLIC -DTSID_QPMAD_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ option(EIGEN_NO_AUTOMATIC_RESIZING
        "If ON, it forbids automatic resizing of dynamics arrays and matrices"
        OFF)
 option(PROXQP_SUPPORT "Support using the proxqp solver" ON)
+option(OSQP_SUPPORT "Support using the osqp solver" ON)
 
 # Project configuration
 if(NOT INSTALL_PYTHON_INTERFACE_ONLY)
@@ -146,6 +147,13 @@ if(PROXQP_SUPPORT)
   list(APPEND ${PROJECT_NAME}_SOLVERS_HEADERS
        include/tsid/solvers/solver-proxqp.hpp)
 endif()
+
+if(OSQP_SUPPORT)
+  find_package(OsqpEigen REQUIRED)
+  list(APPEND ${PROJECT_NAME}_SOLVERS_HEADERS
+       include/tsid/solvers/solver-osqp.hpp)
+endif()
+
 if(qpmad_FOUND)
   list(APPEND ${PROJECT_NAME}_SOLVERS_HEADERS
        include/tsid/solvers/solver-HQP-qpmad.hpp)
@@ -228,6 +236,11 @@ set(${PROJECT_NAME}_SOLVERS_SOURCES
 if(PROXQP_SUPPORT)
   list(APPEND ${PROJECT_NAME}_SOLVERS_SOURCES src/solvers/solver-proxqp.cpp)
 endif()
+
+if(OSQP_SUPPORT)
+  list(APPEND ${PROJECT_NAME}_SOLVERS_SOURCES src/solvers/solver-osqp.cpp)
+endif()
+
 if(qpmad_FOUND)
   list(APPEND ${PROJECT_NAME}_SOLVERS_SOURCES src/solvers/solver-HQP-qpmad.cpp)
 endif()
@@ -263,6 +276,12 @@ if(PROXQP_SUPPORT)
   target_include_directories(${PROJECT_NAME} PUBLIC ${proxsuite_INCLUDE_DIRS})
   target_compile_definitions(${PROJECT_NAME} PUBLIC -DTSID_PROXSUITE_FOUND)
 endif()
+
+if(OSQP_SUPPORT)
+  target_link_libraries(${PROJECT_NAME} PUBLIC OsqpEigen::OsqpEigen)
+  target_compile_definitions(${PROJECT_NAME} PUBLIC -DTSID_OSQP_FOUND)
+endif()
+
 if(qpmad_FOUND)
   target_include_directories(${PROJECT_NAME} PUBLIC ${qpmad_INCLUDE_DIRS})
   target_compile_definitions(${PROJECT_NAME} PUBLIC -DTSID_QPMAD_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,8 @@ option(EIGEN_RUNTIME_NO_MALLOC
 option(EIGEN_NO_AUTOMATIC_RESIZING
        "If ON, it forbids automatic resizing of dynamics arrays and matrices"
        OFF)
-option(PROXQP_SUPPORT "Support using the proxqp solver" OFF)
-option(OSQP_SUPPORT "Support using the osqp solver" OFF)
+option(BUILD_WITH_PROXQP "Support using the proxqp solver" OFF)
+option(BUILD_WITH_OSQP "Support using the osqp solver" OFF)
 
 # Project configuration
 if(NOT INSTALL_PYTHON_INTERFACE_ONLY)
@@ -143,13 +143,13 @@ set(${PROJECT_NAME}_SOLVERS_HEADERS
     include/tsid/solvers/solver-HQP-eiquadprog-rt.hxx
     include/tsid/solvers/solver-HQP-eiquadprog-fast.hpp)
 
-if(PROXQP_SUPPORT)
+if(BUILD_WITH_PROXQP)
   find_package(proxsuite REQUIRED)
   list(APPEND ${PROJECT_NAME}_SOLVERS_HEADERS
        include/tsid/solvers/solver-proxqp.hpp)
 endif()
 
-if(OSQP_SUPPORT)
+if(BUILD_WITH_OSQP)
   find_package(OsqpEigen REQUIRED)
   list(APPEND ${PROJECT_NAME}_SOLVERS_HEADERS
        include/tsid/solvers/solver-osqp.hpp)
@@ -234,11 +234,11 @@ set(${PROJECT_NAME}_SOLVERS_SOURCES
     src/solvers/solver-HQP-qpoases.cpp
     src/solvers/utils.cpp)
 
-if(PROXQP_SUPPORT)
+if(BUILD_WITH_PROXQP)
   list(APPEND ${PROJECT_NAME}_SOLVERS_SOURCES src/solvers/solver-proxqp.cpp)
 endif()
 
-if(OSQP_SUPPORT)
+if(BUILD_WITH_OSQP)
   list(APPEND ${PROJECT_NAME}_SOLVERS_SOURCES src/solvers/solver-osqp.cpp)
 endif()
 
@@ -273,14 +273,14 @@ target_include_directories(${PROJECT_NAME} PUBLIC $<INSTALL_INTERFACE:include>)
 target_link_libraries(${PROJECT_NAME} PUBLIC pinocchio::pinocchio
                                              eiquadprog::eiquadprog)
 
-if(PROXQP_SUPPORT)
-  target_include_directories(${PROJECT_NAME} PUBLIC ${proxsuite_INCLUDE_DIRS})
-  target_compile_definitions(${PROJECT_NAME} PUBLIC -DTSID_PROXSUITE_FOUND)
+if(BUILD_WITH_PROXQP)
+  target_compile_definitions(${PROJECT_NAME} PUBLIC -DTSID_WITH_PROXSUITE)
+  target_link_libraries(${PROJECT_NAME} PUBLIC proxsuite::proxsuite-vectorized)
 endif()
 
-if(OSQP_SUPPORT)
+if(BUILD_WITH_OSQP)
   target_link_libraries(${PROJECT_NAME} PUBLIC OsqpEigen::OsqpEigen)
-  target_compile_definitions(${PROJECT_NAME} PUBLIC -DTSID_OSQP_FOUND)
+  target_compile_definitions(${PROJECT_NAME} PUBLIC -DTSID_WITH_OSQP)
 endif()
 
 if(qpmad_FOUND)

--- a/bindings/python/solvers/HQPData.cpp
+++ b/bindings/python/solvers/HQPData.cpp
@@ -28,7 +28,28 @@ namespace tsid
     }
     void exposeHQPData()
     {
+      typedef solvers::QPDataBaseTpl<double> QPDataBase;
+      typedef solvers::QPDataTpl<double> QPData;
+      typedef solvers::QPDataQuadProgTpl<double> QPDataQuadProg;
+
       HQPPythonVisitor<HQPDatas>::expose("HQPData");
+
+      // expose QP data structures
+      bp::class_<QPDataBase>("QPDataBase")
+        .def_readonly("H", &QPDataBase::H, "Cost matrix")
+        .def_readonly("g", &QPDataBase::g)
+        .def_readonly("CE", &QPDataBase::CE, "Equality constraint matrix")
+        .def_readonly("ce0", &QPDataBase::ce0);
+
+      bp::class_<QPData, bp::bases<QPDataBase>>("QPData")
+        .def_readonly("CI", &QPData::CI, "Inequality constraint matrix")
+        .def_readonly("lb", &QPData::ci_lb, "Inequality constraint lower bound")
+        .def_readonly("ub", &QPData::ci_ub, "Inequality constraint upper bound");
+
+      bp::class_<QPDataQuadProg, bp::bases<QPDataBase>>("QPDataQuadProg")
+        .def_readonly("CI", &QPDataQuadProg::CI, "Inequality constraint matrix (unilateral)")
+        .def_readonly("ci0", &QPDataQuadProg::ci0, "Inequality constraint vector (stacked lower and upper bounds)");
+
     }
   }
 }

--- a/bindings/python/solvers/solver-HQP-eiquadprog.cpp
+++ b/bindings/python/solvers/solver-HQP-eiquadprog.cpp
@@ -27,5 +27,12 @@ namespace tsid
       SolverHQuadProgPythonVisitor<tsid::solvers::SolverHQuadProg>::expose("SolverHQuadProg");
       SolverHQuadProgPythonVisitor<tsid::solvers::SolverHQuadProgFast>::expose("SolverHQuadProgFast");
     }
+
+    void exposeSolverProxQP()
+    {
+#ifdef TSID_PROXSUITE_FOUND
+      SolverProxQPPythonVisitor<tsid::solvers::SolverProxQP>::expose("SolverProxQP");
+#endif
+    }
   }
 }

--- a/bindings/python/solvers/solver-HQP-eiquadprog.cpp
+++ b/bindings/python/solvers/solver-HQP-eiquadprog.cpp
@@ -34,5 +34,12 @@ namespace tsid
       SolverProxQPPythonVisitor<tsid::solvers::SolverProxQP>::expose("SolverProxQP");
 #endif
     }
+
+    void exposeSolverOSQP()
+    {
+#ifdef TSID_OSQP_FOUND
+      SolverOSQPPythonVisitor<tsid::solvers::SolverOSQP>::expose("SolverOSQP");
+#endif
+    }
   }
 }

--- a/bindings/python/solvers/solver-HQP-eiquadprog.cpp
+++ b/bindings/python/solvers/solver-HQP-eiquadprog.cpp
@@ -30,14 +30,14 @@ namespace tsid
 
     void exposeSolverProxQP()
     {
-#ifdef TSID_PROXSUITE_FOUND
+#ifdef TSID_WITH_PROXSUITE
       SolverProxQPPythonVisitor<tsid::solvers::SolverProxQP>::expose("SolverProxQP");
 #endif
     }
 
     void exposeSolverOSQP()
     {
-#ifdef TSID_OSQP_FOUND
+#ifdef TSID_WITH_OSQP
       SolverOSQPPythonVisitor<tsid::solvers::SolverOSQP>::expose("SolverOSQP");
 #endif
     }

--- a/exercizes/ex_4_conf.py
+++ b/exercizes/ex_4_conf.py
@@ -78,7 +78,7 @@ masks_posture = np.ones(nv-6)
 
 # configuration for viewer
 # ----------------------------------------------
-viewer = pin.visualize.GepettoVisualizer
+viewer = pin.visualize.MeshcatVisualizer
 PRINT_N = 500                   # print every PRINT_N time steps
 DISPLAY_N = 20                  # update robot configuration in viwewer every DISPLAY_N time steps
 CAMERA_TRANSFORM = [3.578777551651001, 1.2937744855880737, 0.8885031342506409, 0.4116811454296112, 0.5468055009841919, 0.6109083890914917, 0.3978860676288605]

--- a/exercizes/ex_4_conf.py
+++ b/exercizes/ex_4_conf.py
@@ -78,7 +78,7 @@ masks_posture = np.ones(nv-6)
 
 # configuration for viewer
 # ----------------------------------------------
-viewer = pin.visualize.MeshcatVisualizer
+viewer = pin.visualize.GepettoVisualizer
 PRINT_N = 500                   # print every PRINT_N time steps
 DISPLAY_N = 20                  # update robot configuration in viwewer every DISPLAY_N time steps
 CAMERA_TRANSFORM = [3.578777551651001, 1.2937744855880737, 0.8885031342506409, 0.4116811454296112, 0.5468055009841919, 0.6109083890914917, 0.3978860676288605]

--- a/exercizes/ex_4_plan_LIPM_romeo.py
+++ b/exercizes/ex_4_plan_LIPM_romeo.py
@@ -20,11 +20,17 @@
 # -------
 import numpy as np
 from quadprog import solve_qp
-import LMPC_walking.second_order.reference_trajectories as reference_trajectories
-import LMPC_walking.second_order.motion_model as motion_model
-import LMPC_walking.second_order.cost_function as cost_function
-import LMPC_walking.second_order.constraints as constraints
-import LMPC_walking.second_order.plot_utils as plot_utils
+
+try:
+    import LMPC_walking.second_order.reference_trajectories as reference_trajectories
+    import LMPC_walking.second_order.motion_model as motion_model
+    import LMPC_walking.second_order.cost_function as cost_function
+    import LMPC_walking.second_order.constraints as constraints
+    import LMPC_walking.second_order.plot_utils as plot_utils
+except ModuleNotFoundError as e:
+    print("Please download LMPC_walking from https://github.com/machines-in-motion/lmpc_walking.")
+    raise e
+
 import matplotlib.pyplot as plt
 from plot_utils import *
 import ex_4_conf as conf

--- a/exercizes/ex_4_walking.py
+++ b/exercizes/ex_4_walking.py
@@ -44,7 +44,7 @@ if USE_EIQUADPROG:
 elif USE_PROXQP:
     print("Using proxqp")
     tsid_biped.solver = tsid.SolverProxQP("qp solver")
-    tsid_biped.solver.set_epsilon_absolute(1e-8)
+    tsid_biped.solver.set_epsilon_absolute(1e-5)
     tsid_biped.solver.set_maximum_iterations(int(1e6))
     tsid_biped.solver.set_verbose(VERBOSE)
 

--- a/exercizes/ex_4_walking.py
+++ b/exercizes/ex_4_walking.py
@@ -1,16 +1,26 @@
+import time
 import numpy as np
+import scipy.sparse as spa
+import matplotlib.pyplot as plt
+
+import tsid
+import plot_utils as plut
+import ex_4_conf as conf
+
 from numpy import nan
 from numpy.linalg import norm as norm
-import matplotlib.pyplot as plt
-import plot_utils as plut
-import time
-import ex_4_conf as conf
-#import ex_4_long_conf as conf
 from tsid_biped import TsidBiped
+
 
 print("".center(conf.LINE_WIDTH,'#'))
 print(" Test Walking ".center(conf.LINE_WIDTH, '#'))
 print("".center(conf.LINE_WIDTH,'#'), '\n')
+
+
+USE_EIQUADPROG = 1
+USE_PROXQP = 0
+USE_OSQP = 0
+VERBOSE = 0
 
 PLOT_COM = 1
 PLOT_COP = 1
@@ -18,9 +28,38 @@ PLOT_FOOT_TRAJ = 0
 PLOT_TORQUES = 0
 PLOT_JOINT_VEL = 0
 
-data = np.load(conf.DATA_FILE_TSID)
+try:
+    data = np.load(conf.DATA_FILE_TSID)
+except FileNotFoundError as e:
+    print("To run this walking example, you need to first execute ex_4_plan_LIPM_romeo.py and ex_4_LIPM_to_TSID.")
+    raise e
+    
+tsid_biped = TsidBiped(conf, conf.viewer)
 
-tsid = TsidBiped(conf, conf.viewer)
+# overwrite the default solver
+if USE_EIQUADPROG:
+    print("Using eiquadprog")
+    tsid_biped.solver = tsid.SolverHQuadProgFast("qp solver")
+
+elif USE_PROXQP:
+    print("Using proxqp")
+    tsid_biped.solver = tsid.SolverProxQP("qp solver")
+    tsid_biped.solver.set_epsilon_absolute(1e-8)
+    tsid_biped.solver.set_maximum_iterations(int(1e6))
+    tsid_biped.solver.set_verbose(VERBOSE)
+
+elif USE_OSQP:
+    print("Using osqp")
+    tsid_biped.solver = tsid.SolverOSQP("qp solver")
+    tsid_biped.solver.set_epsilon_absolute(1e-8)
+    tsid_biped.solver.set_maximum_iterations(int(1e6))
+    tsid_biped.solver.set_verbose(VERBOSE)
+
+else:
+    print("Please specify which solver to use.")
+    exit()
+
+tsid_biped.solver.resize(tsid_biped.formulation.nVar, tsid_biped.formulation.nEq, tsid_biped.formulation.nIn)
 
 N = data['com'].shape[1]
 N_pre  = int(conf.T_pre/conf.dt)
@@ -41,9 +80,9 @@ f_RF = np.zeros((6, N+N_post))
 f_LF = np.zeros((6, N+N_post))
 cop_RF = np.zeros((2, N+N_post))
 cop_LF = np.zeros((2, N+N_post))
-tau    = np.zeros((tsid.robot.na, N+N_post))
-q_log  = np.zeros((tsid.robot.nq, N+N_post))
-v_log  = np.zeros((tsid.robot.nv, N+N_post))
+tau    = np.zeros((tsid_biped.robot.na, N+N_post))
+q_log  = np.zeros((tsid_biped.robot.nq, N+N_post))
+v_log  = np.zeros((tsid_biped.robot.nv, N+N_post))
 
 contact_phase = data['contact_phase']
 com_pos_ref = np.asarray(data['com'])
@@ -58,7 +97,7 @@ ddx_LF_ref  = np.asarray(data['ddx_LF'])
 cop_ref     = np.asarray(data['cop'])
 com_acc_des = np.empty((3, N+N_post))*nan # acc_des = acc_ref - Kp*pos_err - Kd*vel_err
 
-x_rf   = tsid.get_placement_RF().translation
+x_rf   = tsid_biped.get_placement_RF().translation
 offset = x_rf - x_RF_ref[:,0]
 for i in range(N):
     com_pos_ref[:,i] += offset + np.array([0.,0.,0.0])
@@ -66,35 +105,40 @@ for i in range(N):
     x_LF_ref[:,i] += offset
 
 t = -conf.T_pre
-q, v = tsid.q, tsid.v
+q, v = tsid_biped.q, tsid_biped.v
 
+qp_data_list = []
+c = 0
+q_list = []
+
+input("Press enter to start")
 for i in range(-N_pre, N+N_post):
     time_start = time.time()
     
     if i==0:
         print("Starting to walk (remove contact left foot)")
-        tsid.remove_contact_LF()
+        tsid_biped.remove_contact_LF()
     elif i>0 and i<N-1:
         if contact_phase[i] != contact_phase[i-1]:
             print("Time %.3f Changing contact phase from %s to %s"%(t, contact_phase[i-1], contact_phase[i]))
             if contact_phase[i] == 'left':
-                tsid.add_contact_LF()
-                tsid.remove_contact_RF()
+                tsid_biped.add_contact_LF()
+                tsid_biped.remove_contact_RF()
             else:
-                tsid.add_contact_RF()
-                tsid.remove_contact_LF()
+                tsid_biped.add_contact_RF()
+                tsid_biped.remove_contact_LF()
     
     
     if i<0:
-        tsid.set_com_ref(com_pos_ref[:,0], 0*com_vel_ref[:,0], 0*com_acc_ref[:,0])
+        tsid_biped.set_com_ref(com_pos_ref[:,0], 0*com_vel_ref[:,0], 0*com_acc_ref[:,0])
     elif i<N:
-        tsid.set_com_ref(com_pos_ref[:,i], com_vel_ref[:,i], com_acc_ref[:,i])
-        tsid.set_LF_3d_ref(x_LF_ref[:,i], dx_LF_ref[:,i], ddx_LF_ref[:,i])
-        tsid.set_RF_3d_ref(x_RF_ref[:,i], dx_RF_ref[:,i], ddx_RF_ref[:,i])
+        tsid_biped.set_com_ref(com_pos_ref[:,i], com_vel_ref[:,i], com_acc_ref[:,i])
+        tsid_biped.set_LF_3d_ref(x_LF_ref[:,i], dx_LF_ref[:,i], ddx_LF_ref[:,i])
+        tsid_biped.set_RF_3d_ref(x_RF_ref[:,i], dx_RF_ref[:,i], ddx_RF_ref[:,i])
     
-    HQPData = tsid.formulation.computeProblemData(t, q, v)
-
-    sol = tsid.solver.solve(HQPData)
+    HQPData = tsid_biped.formulation.computeProblemData(t, q, v)
+    sol = tsid_biped.solver.solve(HQPData)
+    
     if(sol.status!=0):
         print("QP problem could not be solved! Error code:", sol.status)
         break
@@ -105,53 +149,62 @@ for i in range(-N_pre, N+N_post):
     if i>0:
         q_log[:,i] = q
         v_log[:,i] = v
-        tau[:,i] = tsid.formulation.getActuatorForces(sol)
-    dv = tsid.formulation.getAccelerations(sol)
+        tau[:,i] = tsid_biped.formulation.getActuatorForces(sol)
+    dv = tsid_biped.formulation.getAccelerations(sol)
     
     if i>=0:
-        com_pos[:,i] = tsid.robot.com(tsid.formulation.data())
-        com_vel[:,i] = tsid.robot.com_vel(tsid.formulation.data())
-        com_acc[:,i] = tsid.comTask.getAcceleration(dv)
-        com_acc_des[:,i] = tsid.comTask.getDesiredAcceleration
-        x_LF[:,i], dx_LF[:,i], ddx_LF[:,i] = tsid.get_LF_3d_pos_vel_acc(dv)
-        if not tsid.contact_LF_active:
-            ddx_LF_des[:,i] = tsid.leftFootTask.getDesiredAcceleration[:3]
-        x_RF[:,i], dx_RF[:,i], ddx_RF[:,i] = tsid.get_RF_3d_pos_vel_acc(dv)
-        if not tsid.contact_RF_active:
-            ddx_RF_des[:,i] = tsid.rightFootTask.getDesiredAcceleration[:3]
+        com_pos[:,i] = tsid_biped.robot.com(tsid_biped.formulation.data())
+        com_vel[:,i] = tsid_biped.robot.com_vel(tsid_biped.formulation.data())
+        com_acc[:,i] = tsid_biped.comTask.getAcceleration(dv)
+        com_acc_des[:,i] = tsid_biped.comTask.getDesiredAcceleration
+        x_LF[:,i], dx_LF[:,i], ddx_LF[:,i] = tsid_biped.get_LF_3d_pos_vel_acc(dv)
+        if not tsid_biped.contact_LF_active:
+            ddx_LF_des[:,i] = tsid_biped.leftFootTask.getDesiredAcceleration[:3]
+        x_RF[:,i], dx_RF[:,i], ddx_RF[:,i] = tsid_biped.get_RF_3d_pos_vel_acc(dv)
+        if not tsid_biped.contact_RF_active:
+            ddx_RF_des[:,i] = tsid_biped.rightFootTask.getDesiredAcceleration[:3]
         
-        if tsid.formulation.checkContact(tsid.contactRF.name, sol):
-            T_RF = tsid.contactRF.getForceGeneratorMatrix
-            f_RF[:,i] = T_RF @ tsid.formulation.getContactForce(tsid.contactRF.name, sol)
+        if tsid_biped.formulation.checkContact(tsid_biped.contactRF.name, sol):
+            T_RF = tsid_biped.contactRF.getForceGeneratorMatrix
+            f_RF[:,i] = T_RF @ tsid_biped.formulation.getContactForce(tsid_biped.contactRF.name, sol)
             if(f_RF[2,i]>1e-3): 
                 cop_RF[0,i] = f_RF[4,i] / f_RF[2,i]
                 cop_RF[1,i] = -f_RF[3,i] / f_RF[2,i]
-        if tsid.formulation.checkContact(tsid.contactLF.name, sol):
-            T_LF = tsid.contactRF.getForceGeneratorMatrix
-            f_LF[:,i] = T_LF @ tsid.formulation.getContactForce(tsid.contactLF.name, sol)
+        if tsid_biped.formulation.checkContact(tsid_biped.contactLF.name, sol):
+            T_LF = tsid_biped.contactRF.getForceGeneratorMatrix
+            f_LF[:,i] = T_LF @ tsid_biped.formulation.getContactForce(tsid_biped.contactLF.name, sol)
             if(f_LF[2,i]>1e-3): 
                 cop_LF[0,i] = f_LF[4,i] / f_LF[2,i]
                 cop_LF[1,i] = -f_LF[3,i] / f_LF[2,i]
 
     if i%conf.PRINT_N == 0:
         print("Time %.3f"%(t))
-        if tsid.formulation.checkContact(tsid.contactRF.name, sol) and i>=0:
-            print("\tnormal force %s: %.1f"%(tsid.contactRF.name.ljust(20,'.'), f_RF[2,i]))
+        if tsid_biped.formulation.checkContact(tsid_biped.contactRF.name, sol) and i>=0:
+            print("\tnormal force %s: %.1f"%(tsid_biped.contactRF.name.ljust(20,'.'), f_RF[2,i]))
 
-        if tsid.formulation.checkContact(tsid.contactLF.name, sol) and i>=0:
-            print("\tnormal force %s: %.1f"%(tsid.contactLF.name.ljust(20,'.'), f_LF[2,i]))
+        if tsid_biped.formulation.checkContact(tsid_biped.contactLF.name, sol) and i>=0:
+            print("\tnormal force %s: %.1f"%(tsid_biped.contactLF.name.ljust(20,'.'), f_LF[2,i]))
 
-        print("\ttracking err %s: %.3f"%(tsid.comTask.name.ljust(20,'.'), norm(tsid.comTask.position_error, 2)))
+        print("\ttracking err %s: %.3f"%(tsid_biped.comTask.name.ljust(20,'.'), norm(tsid_biped.comTask.position_error, 2)))
         print("\t||v||: %.3f\t ||dv||: %.3f"%(norm(v, 2), norm(dv)))
 
-    q, v = tsid.integrate_dv(q, v, dv, conf.dt)
+    q, v = tsid_biped.integrate_dv(q, v, dv, conf.dt)
     t += conf.dt
+
+    q_list.append(q)
     
-    if i%conf.DISPLAY_N == 0: tsid.display(q)
+    if i%conf.DISPLAY_N == 0: tsid_biped.display(q)
 
     time_spent = time.time() - time_start
     if(time_spent < conf.dt): time.sleep(conf.dt-time_spent)
-    
+
+while True:
+    replay = input("Play video again? [Y]/n: ") or "Y"
+    if replay.lower() == "y":
+        for q in q_list:
+            tsid_biped.display(q)
+    else:
+        break
 # PLOT STUFF
 time = np.arange(0.0, (N+N_post)*conf.dt, conf.dt)
 
@@ -201,6 +254,7 @@ if PLOT_COP:
         leg = ax[i].legend()
         leg.get_frame().set_alpha(0.5)
     
+
 #(f, ax) = plut.create_empty_figure(3,2)
 #ax = ax.reshape((6))
 #for i in range(6):
@@ -240,11 +294,11 @@ if PLOT_FOOT_TRAJ:
     
 if(PLOT_TORQUES):        
     plt.figure()
-    for i in range(tsid.robot.na):
-        tau_normalized = 2*(tau[i,:]-tsid.tau_min[i]) / (tsid.tau_max[i]-tsid.tau_min[i]) - 1
+    for i in range(tsid_biped.robot.na):
+        tau_normalized = 2*(tau[i,:]-tsid_biped.tau_min[i]) / (tsid_biped.tau_max[i]-tsid_biped.tau_min[i]) - 1
         # plot torques only for joints that reached 50% of max torque
         if np.max(np.abs(tau_normalized))>0.5:
-            plt.plot(time, tau_normalized, alpha=0.5, label=tsid.model.names[i+2])
+            plt.plot(time, tau_normalized, alpha=0.5, label=tsid_biped.model.names[i+2])
     plt.plot([time[0], time[-1]], 2*[-1.0], ':')
     plt.plot([time[0], time[-1]], 2*[1.0], ':')
     plt.gca().set_xlabel('Time [s]')
@@ -254,11 +308,11 @@ if(PLOT_TORQUES):
     
 if(PLOT_JOINT_VEL):
     plt.figure()
-    for i in range(tsid.robot.na):
-        v_normalized = 2*(v_log[6+i,:]-tsid.v_min[i]) / (tsid.v_max[i]-tsid.v_min[i]) - 1
+    for i in range(tsid_biped.robot.na):
+        v_normalized = 2*(v_log[6+i,:]-tsid_biped.v_min[i]) / (tsid_biped.v_max[i]-tsid_biped.v_min[i]) - 1
         # plot v only for joints that reached 50% of max v
         if np.max(np.abs(v_normalized))>0.5:
-            plt.plot(time, v_normalized, alpha=0.5, label=tsid.model.names[i+2])
+            plt.plot(time, v_normalized, alpha=0.5, label=tsid_biped.model.names[i+2])
     plt.plot([time[0], time[-1]], 2*[-1.0], ':')
     plt.plot([time[0], time[-1]], 2*[1.0], ':')
     plt.gca().set_xlabel('Time [s]')

--- a/exercizes/tsid_biped.py
+++ b/exercizes/tsid_biped.py
@@ -170,7 +170,7 @@ class TsidBiped:
             elif viewer == pin.visualize.MeshcatVisualizer:
                 self.viz = viewer(self.robot_display.model, self.robot_display.collision_model,
                                   self.robot_display.visual_model)
-                self.viz.initViewer(loadModel=True)
+                self.viz.initViewer(loadModel=True, open=True)
                 self.viz.display(q)
                 
     def display(self, q):

--- a/include/tsid/bindings/python/constraint/constraint-bound.hpp
+++ b/include/tsid/bindings/python/constraint/constraint-bound.hpp
@@ -54,9 +54,9 @@ namespace tsid
         .add_property("lowerBound", &ConstraintPythonVisitor::lowerBound)
         .add_property("upperBound", &ConstraintPythonVisitor::upperBound)
 
-        .def("setVector", (bool (ConstraintBound::*)(const Eigen::VectorXd &) const) &ConstraintBound::setVector, bp::args("vector"), "Set Vector")
-        .def("setLowerBound", (bool (ConstraintBound::*)(const Eigen::VectorXd &) const) &ConstraintBound::setLowerBound, bp::args("lb"), "Set LowerBound")
-        .def("setUpperBound", (bool (ConstraintBound::*)(const Eigen::VectorXd &) const) &ConstraintBound::setUpperBound, bp::args("ub"), "Set UpperBound")
+        .def("setVector", (bool (ConstraintBound::*)(const Eigen::Ref<Eigen::VectorXd> &) const) &ConstraintBound::setVector, bp::args("vector"), "Set Vector")
+        .def("setLowerBound", (bool (ConstraintBound::*)(const Eigen::Ref<Eigen::VectorXd> &) const) &ConstraintBound::setLowerBound, bp::args("lb"), "Set LowerBound")
+        .def("setUpperBound", (bool (ConstraintBound::*)(const Eigen::Ref<Eigen::VectorXd> &) const) &ConstraintBound::setUpperBound, bp::args("ub"), "Set UpperBound")
         ;
       }
       static Eigen::VectorXd vector (const ConstraintBound & self) {return self.vector();}

--- a/include/tsid/bindings/python/constraint/constraint-equality.hpp
+++ b/include/tsid/bindings/python/constraint/constraint-equality.hpp
@@ -55,10 +55,10 @@ namespace tsid
         .add_property("lowerBound", &ConstraintEqPythonVisitor::lowerBound)
         .add_property("upperBound", &ConstraintEqPythonVisitor::upperBound)
 
-        .def("setMatrix", (bool (ConstraintEquality::*)(const Eigen::MatrixXd &) const) &ConstraintEquality::setMatrix, bp::args("matrix"), "Set Matrix")
-        .def("setVector", (bool (ConstraintEquality::*)(const Eigen::VectorXd &) const) &ConstraintEquality::setVector, bp::args("vector"), "Set Vector")
-        .def("setLowerBound", (bool (ConstraintEquality::*)(const Eigen::VectorXd &) const) &ConstraintEquality::setLowerBound, bp::args("lb"), "Set LowerBound")
-        .def("setUpperBound", (bool (ConstraintEquality::*)(const Eigen::VectorXd &) const) &ConstraintEquality::setUpperBound, bp::args("ub"), "Set UpperBound")
+        .def("setMatrix", (bool (ConstraintEquality::*)(const Eigen::Ref<Eigen::MatrixXd> &) const) &ConstraintEquality::setMatrix, bp::args("matrix"), "Set Matrix")
+        .def("setVector", (bool (ConstraintEquality::*)(const Eigen::Ref<Eigen::VectorXd> &) const) &ConstraintEquality::setVector, bp::args("vector"), "Set Vector")
+        .def("setLowerBound", (bool (ConstraintEquality::*)(const Eigen::Ref<Eigen::VectorXd> &) const) &ConstraintEquality::setLowerBound, bp::args("lb"), "Set LowerBound")
+        .def("setUpperBound", (bool (ConstraintEquality::*)(const Eigen::Ref<Eigen::VectorXd> &) const) &ConstraintEquality::setUpperBound, bp::args("ub"), "Set UpperBound")
         
         ;
       }

--- a/include/tsid/bindings/python/constraint/constraint-inequality.hpp
+++ b/include/tsid/bindings/python/constraint/constraint-inequality.hpp
@@ -53,10 +53,10 @@ namespace tsid
         .add_property("lowerBound", &ConstraintIneqPythonVisitor::lowerBound)
         .add_property("upperBound", &ConstraintIneqPythonVisitor::upperBound)
 
-        .def("setMatrix", (bool (ConstraintInequality::*)(const Eigen::MatrixXd &) const) &ConstraintInequality::setMatrix, bp::args("matrix"), "Set Matrix")
-        .def("setVector", (bool (ConstraintInequality::*)(const Eigen::VectorXd &) const) &ConstraintInequality::setVector, bp::args("vector"), "Set Vector")
-        .def("setLowerBound", (bool (ConstraintInequality::*)(const Eigen::VectorXd &) const) &ConstraintInequality::setLowerBound, bp::args("lb"), "Set LowerBound")
-        .def("setUpperBound", (bool (ConstraintInequality::*)(const Eigen::VectorXd &) const) &ConstraintInequality::setUpperBound, bp::args("ub"), "Set UpperBound")
+        .def("setMatrix", (bool (ConstraintInequality::*)(const Eigen::Ref<Eigen::MatrixXd> &) const) &ConstraintInequality::setMatrix, bp::args("matrix"), "Set Matrix")
+        .def("setVector", (bool (ConstraintInequality::*)(const Eigen::Ref<Eigen::VectorXd> &) const) &ConstraintInequality::setVector, bp::args("vector"), "Set Vector")
+        .def("setLowerBound", (bool (ConstraintInequality::*)(const Eigen::Ref<Eigen::VectorXd> &) const) &ConstraintInequality::setLowerBound, bp::args("lb"), "Set LowerBound")
+        .def("setUpperBound", (bool (ConstraintInequality::*)(const Eigen::Ref<Eigen::VectorXd> &) const) &ConstraintInequality::setUpperBound, bp::args("ub"), "Set UpperBound")
         ;
       }
       static Eigen::MatrixXd matrix (const ConstraintInequality & self) {return self.matrix();}

--- a/include/tsid/bindings/python/solvers/HQPOutput.hpp
+++ b/include/tsid/bindings/python/solvers/HQPOutput.hpp
@@ -37,7 +37,7 @@ namespace tsid
       void visit(PyClass& cl) const
       {
         cl
-        .def(bp::init<>("Defulat Constructor"))
+        .def(bp::init<>("Default Constructor"))
         .def(bp::init<int, int, int>((bp::args("nVars", "nEq", "nInCon"))))
         .add_property("x", &HQPOutputPythonVisitor::x)
         .add_property("status", &HQPOutputPythonVisitor::status)

--- a/include/tsid/bindings/python/solvers/expose-solvers.hpp
+++ b/include/tsid/bindings/python/solvers/expose-solvers.hpp
@@ -21,6 +21,7 @@
 
 #include "tsid/bindings/python/solvers/solver-HQP-eiquadprog.hpp"
 #include "tsid/bindings/python/solvers/solver-proxqp.hpp"
+#include "tsid/bindings/python/solvers/solver-osqp.hpp"
 #include "tsid/bindings/python/solvers/HQPData.hpp"
 #include "tsid/bindings/python/solvers/HQPOutput.hpp"
 namespace tsid
@@ -29,6 +30,7 @@ namespace tsid
   {
     void exposeSolverHQuadProg();
     void exposeSolverProxQP();
+    void exposeSolverOSQP();
     void exposeConstraintLevel();
     void exposeHQPData();
     void exposeHQPOutput();
@@ -36,6 +38,7 @@ namespace tsid
     {
       exposeSolverHQuadProg();
       exposeSolverProxQP();
+      exposeSolverOSQP();
       exposeConstraintLevel();
       exposeHQPData();
       exposeHQPOutput();

--- a/include/tsid/bindings/python/solvers/expose-solvers.hpp
+++ b/include/tsid/bindings/python/solvers/expose-solvers.hpp
@@ -20,8 +20,12 @@
 
 
 #include "tsid/bindings/python/solvers/solver-HQP-eiquadprog.hpp"
-#include "tsid/bindings/python/solvers/solver-proxqp.hpp"
-#include "tsid/bindings/python/solvers/solver-osqp.hpp"
+#ifdef TSID_PROXSUITE_FOUND
+  #include "tsid/bindings/python/solvers/solver-proxqp.hpp"
+#endif
+#ifdef TSID_OSQP_FOUND
+  #include "tsid/bindings/python/solvers/solver-osqp.hpp"
+#endif
 #include "tsid/bindings/python/solvers/HQPData.hpp"
 #include "tsid/bindings/python/solvers/HQPOutput.hpp"
 namespace tsid

--- a/include/tsid/bindings/python/solvers/expose-solvers.hpp
+++ b/include/tsid/bindings/python/solvers/expose-solvers.hpp
@@ -20,6 +20,7 @@
 
 
 #include "tsid/bindings/python/solvers/solver-HQP-eiquadprog.hpp"
+#include "tsid/bindings/python/solvers/solver-proxqp.hpp"
 #include "tsid/bindings/python/solvers/HQPData.hpp"
 #include "tsid/bindings/python/solvers/HQPOutput.hpp"
 namespace tsid
@@ -27,12 +28,14 @@ namespace tsid
   namespace python
   {
     void exposeSolverHQuadProg();
+    void exposeSolverProxQP();
     void exposeConstraintLevel();
     void exposeHQPData();
     void exposeHQPOutput();
     inline void exposeSolvers()
     {
       exposeSolverHQuadProg();
+      exposeSolverProxQP();
       exposeConstraintLevel();
       exposeHQPData();
       exposeHQPOutput();

--- a/include/tsid/bindings/python/solvers/expose-solvers.hpp
+++ b/include/tsid/bindings/python/solvers/expose-solvers.hpp
@@ -20,10 +20,10 @@
 
 
 #include "tsid/bindings/python/solvers/solver-HQP-eiquadprog.hpp"
-#ifdef TSID_PROXSUITE_FOUND
+#ifdef TSID_WITH_PROXSUITE
   #include "tsid/bindings/python/solvers/solver-proxqp.hpp"
 #endif
-#ifdef TSID_OSQP_FOUND
+#ifdef TSID_WITH_OSQP
   #include "tsid/bindings/python/solvers/solver-osqp.hpp"
 #endif
 #include "tsid/bindings/python/solvers/HQPData.hpp"

--- a/include/tsid/bindings/python/solvers/solver-HQP-eiquadprog.hpp
+++ b/include/tsid/bindings/python/solvers/solver-HQP-eiquadprog.hpp
@@ -47,7 +47,9 @@ namespace tsid
         .add_property("ObjVal", &Solver::getObjectiveValue, "return obj value")
         .def("solve", &SolverHQuadProgPythonVisitor::solve, bp::args("HQPData"))
         .def("solve", &SolverHQuadProgPythonVisitor::solver_helper, bp::args("HQPData for Python"))
-
+        .add_property("qpData", &Solver::getQPData, "return QP Data object")
+        .def("retrieveQPData", &Solver::retrieveQPData, bp::args("HQPData"))
+        .def("retrieveQPData", &SolverHQuadProgPythonVisitor::retrieveQPData, bp::args("HQPData for Python"))
         ;
       }
        
@@ -66,6 +68,12 @@ namespace tsid
           output = self.solve(data);
          
           return output;
+      }
+
+      static solvers::QPDataQuadProg retrieveQPData(Solver & self, HQPDatas & HQPDatas){
+          solvers::HQPData data = HQPDatas.get();
+          self.retrieveQPData(data);
+          return self.getQPData();
       }
 
       static void expose(const std::string & class_name)

--- a/include/tsid/bindings/python/solvers/solver-HQP-eiquadprog.hpp
+++ b/include/tsid/bindings/python/solvers/solver-HQP-eiquadprog.hpp
@@ -41,7 +41,7 @@ namespace tsid
       void visit(PyClass& cl) const
       {
         cl
-        .def(bp::init<std::string>((bp::arg("name")), "Default Constructor with name"))
+        .def(bp::init<const std::string &>((bp::arg("name")), "Default Constructor with name"))
         
         .def("resize", &SolverHQuadProgPythonVisitor::resize, bp::args("n", "neq", "nin"))
         .add_property("ObjVal", &Solver::getObjectiveValue, "return obj value")
@@ -63,7 +63,7 @@ namespace tsid
       }
       static solvers::HQPOutput solver_helper(Solver & self, HQPDatas & HQPDatas){
           solvers::HQPOutput output;
-          solvers::HQPData data = HQPDatas.get();
+          solvers::HQPData &data = HQPDatas.get();
 
           output = self.solve(data);
          

--- a/include/tsid/bindings/python/solvers/solver-osqp.hpp
+++ b/include/tsid/bindings/python/solvers/solver-osqp.hpp
@@ -41,7 +41,7 @@ namespace tsid
       void visit(PyClass& cl) const
       {
         cl
-        .def(bp::init<std::string>((bp::arg("name")), "Default Constructor with name"))
+        .def(bp::init<const std::string &>((bp::arg("name")), "Default Constructor with name"))
         .def("resize", &SolverOSQPPythonVisitor::resize, bp::args("n", "neq", "nin"))
         .add_property("ObjVal", &Solver::getObjectiveValue, "return obj value")
         .def("solve", &SolverOSQPPythonVisitor::solve, bp::args("HQPData"))
@@ -68,7 +68,7 @@ namespace tsid
       }
       static solvers::HQPOutput solver_helper(Solver & self, HQPDatas & HQPDatas){
           solvers::HQPOutput output;
-          solvers::HQPData data = HQPDatas.get();
+          solvers::HQPData &data = HQPDatas.get();
 
           output = self.solve(data);
          
@@ -76,7 +76,7 @@ namespace tsid
       }
 
       static solvers::QPData retrieveQPData(Solver & self, HQPDatas & HQPDatas){
-          solvers::HQPData data = HQPDatas.get();
+          solvers::HQPData &data = HQPDatas.get();
           self.retrieveQPData(data);
           return self.getQPData();
       }

--- a/include/tsid/bindings/python/solvers/solver-osqp.hpp
+++ b/include/tsid/bindings/python/solvers/solver-osqp.hpp
@@ -1,0 +1,98 @@
+//
+// Copyright (c) 2022 INRIA
+//
+// This file is part of tsid
+// tsid is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+// tsid is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Lesser Public License for more details. You should have
+// received a copy of the GNU Lesser General Public License along with
+// tsid If not, see
+// <http://www.gnu.org/licenses/>.
+//
+
+#ifndef __tsid_python_solver_osqp_hpp__
+#define __tsid_python_solver_osqp_hpp__
+
+#include "tsid/bindings/python/fwd.hpp"
+
+#include "tsid/solvers/solver-osqp.hpp"
+
+#include "tsid/solvers/solver-HQP-output.hpp"
+#include "tsid/solvers/fwd.hpp"
+#include "tsid/bindings/python/utils/container.hpp"
+
+namespace tsid
+{
+  namespace python
+  {    
+    namespace bp = boost::python;
+    
+    template<typename Solver>
+    struct SolverOSQPPythonVisitor
+    : public boost::python::def_visitor< SolverOSQPPythonVisitor<Solver> >
+    {
+      template<class PyClass>     
+
+      void visit(PyClass& cl) const
+      {
+        cl
+        .def(bp::init<std::string>((bp::arg("name")), "Default Constructor with name"))
+        .def("resize", &SolverOSQPPythonVisitor::resize, bp::args("n", "neq", "nin"))
+        .add_property("ObjVal", &Solver::getObjectiveValue, "return obj value")
+        .def("solve", &SolverOSQPPythonVisitor::solve, bp::args("HQPData"))
+        .def("solve", &SolverOSQPPythonVisitor::solver_helper, bp::args("HQPData for Python"))
+        .add_property("qpData", &Solver::getQPData, "return QP Data object")
+        .def("retrieveQPData", &SolverOSQPPythonVisitor::retrieveQPData, bp::args("HQPData for Python"))
+        .def("set_maximum_iterations", &Solver::setMaximumIterations)
+        .def("set_sigma", &Solver::setSigma)
+        .def("set_alpha", &Solver::setAlpha)
+        .def("set_rho", &Solver::setRho)
+        .def("set_epsilon_absolute", &Solver::setEpsilonAbsolute)
+        .def("set_epsilon_relative", &Solver::setEpsilonRelative)
+        .def("set_verbose", &Solver::setVerbose)
+        ;
+      }
+       
+      static void resize(Solver & self, unsigned int n, unsigned int neq, unsigned int nin){
+          return self.resize(n, neq, nin);
+      }  
+      static solvers::HQPOutput solve(Solver & self, const solvers::HQPData & problemData){
+          solvers::HQPOutput output;
+          output = self.solve(problemData);
+          return output;
+      }
+      static solvers::HQPOutput solver_helper(Solver & self, HQPDatas & HQPDatas){
+          solvers::HQPOutput output;
+          solvers::HQPData data = HQPDatas.get();
+
+          output = self.solve(data);
+         
+          return output;
+      }
+
+      static solvers::QPData retrieveQPData(Solver & self, HQPDatas & HQPDatas){
+          solvers::HQPData data = HQPDatas.get();
+          self.retrieveQPData(data);
+          return self.getQPData();
+      }
+
+      static void expose(const std::string & class_name)
+      {
+        std::string doc = "Solver osqp info.";
+        bp::class_<Solver>(class_name.c_str(),
+                          doc.c_str(),
+                          bp::no_init)
+        .def(SolverOSQPPythonVisitor<Solver>());   
+      }    
+    };
+
+  }
+}
+
+
+#endif // ifndef __tsid_python_solver_osqp_hpp__

--- a/include/tsid/bindings/python/solvers/solver-proxqp.hpp
+++ b/include/tsid/bindings/python/solvers/solver-proxqp.hpp
@@ -1,0 +1,97 @@
+//
+// Copyright (c) 2022 INRIA
+//
+// This file is part of tsid
+// tsid is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+// tsid is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Lesser Public License for more details. You should have
+// received a copy of the GNU Lesser General Public License along with
+// tsid If not, see
+// <http://www.gnu.org/licenses/>.
+//
+
+#ifndef __tsid_python_solver_proxqp_hpp__
+#define __tsid_python_solver_proxqp_hpp__
+
+#include "tsid/bindings/python/fwd.hpp"
+
+#include "tsid/solvers/solver-proxqp.hpp"
+
+#include "tsid/solvers/solver-HQP-output.hpp"
+#include "tsid/solvers/fwd.hpp"
+#include "tsid/bindings/python/utils/container.hpp"
+
+namespace tsid
+{
+  namespace python
+  {    
+    namespace bp = boost::python;
+
+    template<typename Solver>
+    struct SolverProxQPPythonVisitor
+    : public boost::python::def_visitor< SolverProxQPPythonVisitor<Solver> >
+    {
+      template<class PyClass>     
+
+      void visit(PyClass& cl) const
+      {
+        cl
+        .def(bp::init<std::string>((bp::arg("name")), "Default Constructor with name"))
+        .def("resize", &SolverProxQPPythonVisitor::resize, bp::args("n", "neq", "nin"))
+        .add_property("ObjVal", &Solver::getObjectiveValue, "return obj value")
+        .def("solve", &SolverProxQPPythonVisitor::solve, bp::args("HQPData"))
+        .def("solve", &SolverProxQPPythonVisitor::solver_helper, bp::args("HQPData for Python"))
+        .add_property("qpData", &Solver::getQPData, "return QP Data object")
+        .def("retrieveQPData", &SolverProxQPPythonVisitor::retrieveQPData, bp::args("HQPData for Python"))
+        .def("set_maximum_iterations", &Solver::setMaximumIterations)
+        .def("set_mu_inequality", &Solver::setMuInequality)
+        .def("set_mu_equality", &Solver::setMuEquality)
+        .def("set_rho", &Solver::setRho)
+        .def("set_epsilon_absolute", &Solver::setEpsilonAbsolute)
+        .def("set_epsilon_relative", &Solver::setEpsilonRelative)
+        .def("set_verbose", &Solver::setVerbose)
+        ;
+      }
+       
+      static void resize(Solver & self, unsigned int n, unsigned int neq, unsigned int nin){
+          return self.resize(n, neq, nin);
+      }  
+      static solvers::HQPOutput solve(Solver & self, const solvers::HQPData & problemData){
+          solvers::HQPOutput output;
+          output = self.solve(problemData);
+          return output;
+      }
+      static solvers::HQPOutput solver_helper(Solver & self, HQPDatas & HQPDatas){
+          solvers::HQPOutput output;
+          solvers::HQPData data = HQPDatas.get();
+
+          output = self.solve(data);
+         
+          return output;
+      }
+
+      static solvers::QPData retrieveQPData(Solver & self, HQPDatas & HQPDatas){
+          solvers::HQPData data = HQPDatas.get();
+          self.retrieveQPData(data);
+          return self.getQPData();
+      }
+
+      static void expose(const std::string & class_name)
+      {
+        std::string doc = "Solver proxqp info.";
+        bp::class_<Solver>(class_name.c_str(),
+                          doc.c_str(),
+                          bp::no_init)
+        .def(SolverProxQPPythonVisitor<Solver>());   
+      }    
+    };
+  }
+}
+
+
+#endif // ifndef __tsid_python_solver_proxqp_hpp__

--- a/include/tsid/bindings/python/solvers/solver-proxqp.hpp
+++ b/include/tsid/bindings/python/solvers/solver-proxqp.hpp
@@ -41,7 +41,7 @@ namespace tsid
       void visit(PyClass& cl) const
       {
         cl
-        .def(bp::init<std::string>((bp::arg("name")), "Default Constructor with name"))
+        .def(bp::init<const std::string &>((bp::arg("name")), "Default Constructor with name"))
         .def("resize", &SolverProxQPPythonVisitor::resize, bp::args("n", "neq", "nin"))
         .add_property("ObjVal", &Solver::getObjectiveValue, "return obj value")
         .def("solve", &SolverProxQPPythonVisitor::solve, bp::args("HQPData"))
@@ -68,7 +68,7 @@ namespace tsid
       }
       static solvers::HQPOutput solver_helper(Solver & self, HQPDatas & HQPDatas){
           solvers::HQPOutput output;
-          solvers::HQPData data = HQPDatas.get();
+          solvers::HQPData &data = HQPDatas.get();
 
           output = self.solve(data);
          
@@ -76,7 +76,7 @@ namespace tsid
       }
 
       static solvers::QPData retrieveQPData(Solver & self, HQPDatas & HQPDatas){
-          solvers::HQPData data = HQPDatas.get();
+          solvers::HQPData &data = HQPDatas.get();
           self.retrieveQPData(data);
           return self.getQPData();
       }

--- a/include/tsid/bindings/python/utils/container.hpp
+++ b/include/tsid/bindings/python/utils/container.hpp
@@ -111,10 +111,10 @@ namespace tsid
             m_std_hqp.push_back(cons->get());
         }
 
-        inline HQPData get (){
+        inline HQPData & get (){
             return m_std_hqp;
         }
-        inline bool set (HQPData data){
+        inline bool set (const HQPData & data){
             m_std_hqp = data;
             return true;
         }

--- a/include/tsid/solvers/fwd.hpp
+++ b/include/tsid/solvers/fwd.hpp
@@ -46,6 +46,9 @@ namespace tsid
 #ifdef TSID_PROXSUITE_FOUND
       ,SOLVER_HQP_PROXSUITE
 #endif
+#ifdef TSID_OSQP_FOUND
+      ,SOLVER_HQP_OSQP
+#endif
 #ifdef QPOASES_FOUND
       ,SOLVER_HQP_OASES
 #endif

--- a/include/tsid/solvers/fwd.hpp
+++ b/include/tsid/solvers/fwd.hpp
@@ -43,6 +43,9 @@ namespace tsid
 #ifdef TSID_QPMAD_FOUND
       ,SOLVER_HQP_QPMAD
 #endif
+#ifdef TSID_PROXSUITE_FOUND
+      ,SOLVER_HQP_PROXSUITE
+#endif
 #ifdef QPOASES_FOUND
       ,SOLVER_HQP_OASES
 #endif

--- a/include/tsid/solvers/fwd.hpp
+++ b/include/tsid/solvers/fwd.hpp
@@ -44,7 +44,7 @@ namespace tsid
       ,SOLVER_HQP_QPMAD
 #endif
 #ifdef TSID_PROXSUITE_FOUND
-      ,SOLVER_HQP_PROXSUITE
+      ,SOLVER_HQP_PROXQP
 #endif
 #ifdef TSID_OSQP_FOUND
       ,SOLVER_HQP_OSQP

--- a/include/tsid/solvers/fwd.hpp
+++ b/include/tsid/solvers/fwd.hpp
@@ -43,10 +43,10 @@ namespace tsid
 #ifdef TSID_QPMAD_FOUND
       ,SOLVER_HQP_QPMAD
 #endif
-#ifdef TSID_PROXSUITE_FOUND
+#ifdef TSID_WITH_PROXSUITE
       ,SOLVER_HQP_PROXQP
 #endif
-#ifdef TSID_OSQP_FOUND
+#ifdef TSID_WITH_OSQP
       ,SOLVER_HQP_OSQP
 #endif
 #ifdef QPOASES_FOUND

--- a/include/tsid/solvers/fwd.hpp
+++ b/include/tsid/solvers/fwd.hpp
@@ -22,6 +22,7 @@
 
 #include "tsid/config.hh"
 #include "tsid/math/fwd.hpp"
+#include "tsid/solvers/solver-qpData.hpp"
 #include <pinocchio/container/aligned-vector.hpp>
 
 #define DEFAULT_HESSIAN_REGULARIZATION 1e-8
@@ -91,6 +92,9 @@ namespace tsid
     typedef pinocchio::container::aligned_vector<ConstraintLevel> HQPData;
     typedef pinocchio::container::aligned_vector<ConstConstraintLevel> ConstHQPData;
     
+    typedef QPDataTpl<double> QPData;
+    typedef QPDataBaseTpl<double> QPDataBase;
+    typedef QPDataQuadProgTpl<double> QPDataQuadProg;
     
   }
 }

--- a/include/tsid/solvers/solver-HQP-base.hpp
+++ b/include/tsid/solvers/solver-HQP-base.hpp
@@ -48,13 +48,17 @@ namespace tsid
       SolverHQPBase(const std::string & name);
       virtual ~SolverHQPBase() {};
 
-      virtual const std::string & name() { return m_name; }
+      virtual const std::string & name() const { return m_name; }
 
       virtual void resize(unsigned int n, unsigned int neq, unsigned int nin) = 0;
 
       /** Solve the specified Hierarchical Quadratic Program.
        */
       virtual const HQPOutput & solve(const HQPData & problemData) = 0;
+
+      /** Retrieve the matrices describing a QP problem from the problem data. */
+      virtual void retrieveQPData(const HQPData & problemData, 
+                                  const bool hessianRegularization) = 0;
 
       /** Get the objective value of the last solved problem. */
       virtual double getObjectiveValue() = 0;
@@ -79,7 +83,7 @@ namespace tsid
 
       std::string           m_name;
       bool                  m_useWarmStart;   // true if the solver is allowed to warm start
-      int                   m_maxIter;        // max number of iterations
+      unsigned int          m_maxIter;        // max number of iterations
       double                m_maxTime;        // max time to solve the HQP [s]
       HQPOutput             m_output;
     };

--- a/include/tsid/solvers/solver-HQP-eiquadprog-fast.hpp
+++ b/include/tsid/solvers/solver-HQP-eiquadprog-fast.hpp
@@ -47,6 +47,13 @@ namespace tsid
        */
       const HQPOutput & solve(const HQPData & problemData);
 
+      /** Retrieve the matrices describing a QP problem from the problem data. */
+      void retrieveQPData(const HQPData & problemData, 
+                          const bool hessianRegularization = true);
+
+      /** Return the QP data object. */
+      const QPDataQuadProg getQPData() const { return m_qpData; }
+
       /** Get the objective value of the last solved problem. */
       double getObjectiveValue();
 
@@ -60,14 +67,7 @@ namespace tsid
       // <nVars, nEqCon, 2*nIneqCon>
       eiquadprog::solvers::EiquadprogFast m_solver; 
 
-      Matrix m_H;
-      Vector m_g;
-      Matrix m_CE;
-      Vector m_ce0;
-      Matrix m_CI;  /// twice the rows because inequality constraints are bilateral
-      Vector m_ci0;
       double m_objValue;
-
       double m_hessian_regularization;
 
       Eigen::VectorXi m_activeSet;  /// vector containing the indexes of the active inequalities
@@ -76,6 +76,8 @@ namespace tsid
       unsigned int m_neq;  /// number of equality constraints
       unsigned int m_nin;  /// number of inequality constraints
       unsigned int m_n;    /// number of variables
+      
+      QPDataQuadProgTpl<double> m_qpData;
     };
   }
 }

--- a/include/tsid/solvers/solver-HQP-eiquadprog-fast.hpp
+++ b/include/tsid/solvers/solver-HQP-eiquadprog-fast.hpp
@@ -18,6 +18,7 @@
 #ifndef __invdyn_solvers_hqp_eiquadprog_fast_hpp__
 #define __invdyn_solvers_hqp_eiquadprog_fast_hpp__
 
+#include "tsid/deprecated.hh"
 #include "tsid/solvers/solver-HQP-base.hpp"
 #include "eiquadprog/eiquadprog-fast.hpp"
 
@@ -67,6 +68,12 @@ namespace tsid
       // <nVars, nEqCon, 2*nIneqCon>
       eiquadprog::solvers::EiquadprogFast m_solver; 
 
+      TSID_DEPRECATED Matrix m_H;
+      TSID_DEPRECATED Vector m_g;
+      TSID_DEPRECATED Matrix m_CE;
+      TSID_DEPRECATED Vector m_ce0;
+      TSID_DEPRECATED Matrix m_CI;  /// twice the rows because inequality constraints are bilateral
+      TSID_DEPRECATED Vector m_ci0;
       double m_objValue;
       double m_hessian_regularization;
 

--- a/include/tsid/solvers/solver-HQP-eiquadprog-rt.hpp
+++ b/include/tsid/solvers/solver-HQP-eiquadprog-rt.hpp
@@ -51,6 +51,14 @@ namespace tsid
        */
       const HQPOutput & solve(const HQPData & problemData);
 
+      // TODO: change eiquadprog-rt to new API
+      /** Retrieve the matrices describing a QP problem from the problem data. */
+      void retrieveQPData(const HQPData & /*problemData*/, 
+                          const bool /*hessianRegularization = true*/){};
+
+      // /** Return the QP data object. */
+      // const QPDataQuadProg getQPData() const { return m_qpData; }
+
       /** Get the objective value of the last solved problem. */
       double getObjectiveValue();
 

--- a/include/tsid/solvers/solver-HQP-eiquadprog.hpp
+++ b/include/tsid/solvers/solver-HQP-eiquadprog.hpp
@@ -47,6 +47,13 @@ namespace tsid
        */
       const HQPOutput & solve(const HQPData & problemData);
 
+      /** Retrieve the matrices describing a QP problem from the problem data. */
+      void retrieveQPData(const HQPData & problemData, 
+                          const bool hessianRegularization = true);
+
+      /** Return the QP data object. */
+      const QPDataQuadProg getQPData() const { return m_qpData; }
+
       /** Get the objective value of the last solved problem. */
       double getObjectiveValue();
 
@@ -54,14 +61,7 @@ namespace tsid
 
       void sendMsg(const std::string & s);
 
-      Matrix m_H;
-      Vector m_g;
-      Matrix m_CE;
-      Vector m_ce0;
-      Matrix m_CI;
-      Vector m_ci0;
       double m_objValue;
-
       double m_hessian_regularization;
 
       Eigen::VectorXi m_activeSet;  /// vector containing the indexes of the active inequalities
@@ -80,6 +80,8 @@ namespace tsid
       unsigned int m_neq;  /// number of equality constraints
       unsigned int m_nin;  /// number of inequality constraints
       unsigned int m_n;    /// number of variables
+
+      QPDataQuadProgTpl<double> m_qpData;
     };
   }
 }

--- a/include/tsid/solvers/solver-HQP-eiquadprog.hpp
+++ b/include/tsid/solvers/solver-HQP-eiquadprog.hpp
@@ -18,6 +18,7 @@
 #ifndef __invdyn_solvers_hqp_eiquadprog_hpp__
 #define __invdyn_solvers_hqp_eiquadprog_hpp__
 
+#include "tsid/deprecated.hh"
 #include <tsid/solvers/solver-HQP-base.hpp>
 
 namespace tsid
@@ -61,6 +62,12 @@ namespace tsid
 
       void sendMsg(const std::string & s);
 
+      TSID_DEPRECATED Matrix m_H;
+      TSID_DEPRECATED Vector m_g;
+      TSID_DEPRECATED Matrix m_CE;
+      TSID_DEPRECATED Vector m_ce0;
+      TSID_DEPRECATED Matrix m_CI;
+      TSID_DEPRECATED Vector m_ci0;
       double m_objValue;
       double m_hessian_regularization;
 

--- a/include/tsid/solvers/solver-HQP-output.hpp
+++ b/include/tsid/solvers/solver-HQP-output.hpp
@@ -45,12 +45,12 @@ namespace tsid
       
       HQPOutput(){}
       
-      HQPOutput(int nVars, int nEqCon, int nInCon)
+      HQPOutput(unsigned int nVars, unsigned int nEqCon, unsigned int nInCon)
       {
         resize(nVars, nEqCon, nInCon);
       }
       
-      void resize(int nVars, int nEqCon, int nInCon)
+      void resize(unsigned int nVars, unsigned int nEqCon, unsigned int nInCon)
       {
         x.resize(nVars);
         lambda.resize(nEqCon+nInCon);

--- a/include/tsid/solvers/solver-osqp.hpp
+++ b/include/tsid/solvers/solver-osqp.hpp
@@ -22,6 +22,15 @@
 #include "OsqpEigen/OsqpEigen.h"
 #include <Eigen/Sparse>
 
+
+#ifdef PROFILE_OSQP
+#define START_PROFILER_OSQP(x) START_PROFILER(x)
+#define STOP_PROFILER_OSQP(x) STOP_PROFILER(x)
+#else
+#define START_PROFILER_OSQP(x)
+#define STOP_PROFILER_OSQP(x)
+#endif
+
 namespace tsid
 {
   namespace solvers

--- a/include/tsid/solvers/solver-osqp.hpp
+++ b/include/tsid/solvers/solver-osqp.hpp
@@ -1,0 +1,97 @@
+//
+// Copyright (c) 2022 INRIA
+//
+// This file is part of tsid
+// tsid is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+// tsid is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Lesser Public License for more details. You should have
+// received a copy of the GNU Lesser General Public License along with
+// tsid If not, see
+// <http://www.gnu.org/licenses/>.
+//
+
+#ifndef __solvers_osqp_hpp__
+#define __solvers_osqp_hpp__
+
+#include "tsid/solvers/solver-HQP-base.hpp"
+#include "OsqpEigen/OsqpEigen.h"
+#include <Eigen/Sparse>
+
+namespace tsid
+{
+  namespace solvers
+  {
+    /**
+     * @brief
+     */
+    class TSID_DLLAPI SolverOSQP : public SolverHQPBase
+    {
+    public:
+      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      
+      typedef math::Matrix Matrix;
+      typedef math::Vector Vector;
+      typedef math::RefVector RefVector;
+      typedef math::ConstRefVector ConstRefVector;
+      typedef math::ConstRefMatrix ConstRefMatrix;
+
+      SolverOSQP(const std::string & name);
+      SolverOSQP(const SolverOSQP & other);
+
+      void resize(unsigned int n, unsigned int neq, unsigned int nin);
+
+      /** Retrieve the matrices describing a QP problem from the problem data. */
+      void retrieveQPData(const HQPData & problemData, const bool hessianRegularization = false);
+      
+      /** Return the QP data object. */
+      const QPData getQPData() const { return m_qpData; }
+
+      /** Solve the given Hierarchical Quadratic Program. */
+      const HQPOutput & solve(const HQPData & problemData);
+
+      /** Get the objective value of the last solved problem. */
+      double getObjectiveValue();
+
+      /** Set the current maximum number of iterations performed by the solver. */
+      bool setMaximumIterations(unsigned int maxIter);
+
+      void setSigma(double sigma);
+      void setAlpha(double alpha);
+      void setRho(double rho);
+      void setEpsilonAbsolute(double epsAbs);
+      void setEpsilonRelative(double epsRel);
+      void setVerbose(bool isVerbose = false);
+
+
+    protected:
+
+      void sendMsg(const std::string & s);
+
+      double m_objValue;
+      double m_hessian_regularization;
+
+      OsqpEigen::Solver m_solver;
+
+      unsigned int m_neq;  /// number of equality constraints
+      unsigned int m_nin;  /// number of inequality constraints
+      unsigned int m_n;    /// number of variables
+
+      QPDataTpl<double> m_qpData;
+
+      double m_rho;
+      double m_sigma;
+      double m_alpha;
+      double m_epsAbs;
+      double m_epsRel;
+      bool m_isVerbose;
+      bool m_isDataInitialized;
+    };
+  }
+}
+
+#endif // ifndef __solvers_osqp_hpp__

--- a/include/tsid/solvers/solver-proxqp.hpp
+++ b/include/tsid/solvers/solver-proxqp.hpp
@@ -23,6 +23,15 @@
 #include <proxsuite/proxqp/sparse/sparse.hpp>
 #include <proxsuite/proxqp/results.hpp>
 
+
+#ifdef PROFILE_PROXQP
+#define START_PROFILER_PROXQP(x) START_PROFILER(x)
+#define STOP_PROFILER_PROXQP(x) STOP_PROFILER(x)
+#else
+#define START_PROFILER_PROXQP(x)
+#define STOP_PROFILER_PROXQP(x)
+#endif
+
 using namespace proxsuite;
 using namespace proxsuite::proxqp;
 

--- a/include/tsid/solvers/solver-proxqp.hpp
+++ b/include/tsid/solvers/solver-proxqp.hpp
@@ -1,0 +1,99 @@
+//
+// Copyright (c) 2022 INRIA
+//
+// This file is part of tsid
+// tsid is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+// tsid is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Lesser Public License for more details. You should have
+// received a copy of the GNU Lesser General Public License along with
+// tsid If not, see
+// <http://www.gnu.org/licenses/>.
+//
+
+#ifndef __solvers_proxqp_hpp__
+#define __solvers_proxqp_hpp__
+
+#include "tsid/solvers/solver-HQP-base.hpp"
+#include <proxsuite/proxqp/dense/dense.hpp>
+#include <proxsuite/proxqp/sparse/sparse.hpp>
+#include <proxsuite/proxqp/results.hpp>
+
+using namespace proxsuite;
+using namespace proxsuite::proxqp;
+
+namespace tsid
+{
+  namespace solvers
+  {
+    /**
+     * @brief
+     */
+    class TSID_DLLAPI SolverProxQP : public SolverHQPBase
+    {
+    public:
+      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      
+      typedef math::Matrix Matrix;
+      typedef math::Vector Vector;
+      typedef math::RefVector RefVector;
+      typedef math::ConstRefVector ConstRefVector;
+      typedef math::ConstRefMatrix ConstRefMatrix;
+
+      SolverProxQP(const std::string & name);
+
+      void resize(unsigned int n, unsigned int neq, unsigned int nin);
+
+      /** Retrieve the matrices describing a QP problem from the problem data. */
+      void retrieveQPData(const HQPData & problemData, const bool hessianRegularization = false);
+
+      /** Return the QP data object. */
+      const QPData getQPData() const { return m_qpData; }
+
+      /** Solve the given Hierarchical Quadratic Program
+       */
+      const HQPOutput & solve(const HQPData & problemData);
+
+      /** Get the objective value of the last solved problem. */
+      double getObjectiveValue();
+
+      /** Set the current maximum number of iterations performed by the solver. */
+      bool setMaximumIterations(unsigned int maxIter);
+
+      void setMuInequality(double muIn);
+      void setMuEquality(double muEq);
+      void setRho(double rho);
+      void setEpsilonAbsolute(double epsAbs);
+      void setEpsilonRelative(double epsRel);
+      void setVerbose(bool isVerbose = false);
+
+    protected:
+
+      void sendMsg(const std::string & s);
+
+      double m_objValue;
+      double m_hessian_regularization;
+
+      dense::QP<double> m_solver;
+
+      unsigned int m_neq;  /// number of equality constraints
+      unsigned int m_nin;  /// number of inequality constraints
+      unsigned int m_n;    /// number of variables
+
+      QPDataTpl<double> m_qpData;
+
+      double m_rho;
+      double m_muIn;
+      double m_muEq;
+      double m_epsAbs;
+      double m_epsRel;
+      bool m_isVerbose;
+    };
+  }
+}
+
+#endif // ifndef __solvers_proxqp_hpp__

--- a/include/tsid/solvers/solver-qpData.hpp
+++ b/include/tsid/solvers/solver-qpData.hpp
@@ -1,0 +1,62 @@
+//
+// Copyright (c) 2022 INRIA
+//
+// This file is part of tsid
+// tsid is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+// tsid is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Lesser Public License for more details. You should have
+// received a copy of the GNU Lesser General Public License along with
+// tsid If not, see
+// <http://www.gnu.org/licenses/>.
+//
+
+#ifndef __solvers_qpdata_hpp__
+#define __solvers_qpdata_hpp__
+
+namespace tsid
+{
+  namespace solvers
+  {
+    
+    template <typename scalar_>
+    struct QPDataBaseTpl
+    {
+      typedef Eigen::Matrix<scalar_,Eigen::Dynamic,1> Vector;
+      typedef Eigen::Matrix<scalar_,Eigen::Dynamic,Eigen::Dynamic> Matrix;
+
+      Matrix H;  // cost to minimize
+      Vector g;
+      Matrix CE;  // equality constraints
+      Vector ce0;
+    };
+
+    template <typename scalar_>
+    struct QPDataTpl : QPDataBaseTpl<scalar_>
+    {
+      typedef Eigen::Matrix<scalar_,Eigen::Dynamic,1> Vector;
+      typedef Eigen::Matrix<scalar_,Eigen::Dynamic,Eigen::Dynamic> Matrix;
+
+      Matrix CI;  // inequality constraints
+      Vector ci_lb;  // lower bound
+      Vector ci_ub;  // upper bound
+    };
+
+    template <typename scalar_>
+    struct QPDataQuadProgTpl : QPDataBaseTpl<scalar_>
+    {
+      typedef Eigen::Matrix<scalar_,Eigen::Dynamic,1> Vector;
+      typedef Eigen::Matrix<scalar_,Eigen::Dynamic,Eigen::Dynamic> Matrix;
+
+      Matrix CI;  // inequality constraints, one-sided
+      Vector ci0;  // stack of lower and upper bounds
+    };    
+  }
+}
+
+#endif // ifndef __solvers_qpdata_hpp__
+

--- a/src/solvers/solver-HQP-eiquadprog-fast.cpp
+++ b/src/solvers/solver-HQP-eiquadprog-fast.cpp
@@ -55,24 +55,25 @@ namespace tsid
 #ifndef NDEBUG
         sendMsg("Resizing equality constraints from "+toString(m_neq)+" to "+toString(neq));
 #endif
-        m_CE.resize(neq, n);
-        m_ce0.resize(neq);
+        m_qpData.CE.resize(neq, n);
+        m_qpData.ce0.resize(neq);
       }
       if(resizeIn)
       {
 #ifndef NDEBUG
         sendMsg("Resizing inequality constraints from "+toString(m_nin)+" to "+toString(nin));
 #endif
-        m_CI.resize(2*nin, n);
-        m_ci0.resize(2*nin);
+        m_qpData.CI.resize(2*nin, n);
+        m_qpData.ci0.resize(2*nin);
       }
       if(resizeVar)
       {
 #ifndef NDEBUG
         sendMsg("Resizing Hessian from "+toString(m_n)+" to "+toString(n));
 #endif
-        m_H.resize(n, n);
-        m_g.resize(n);
+        m_qpData.H.resize(n, n);
+        m_qpData.g.resize(n);
+        m_output.x.resize(n);
       }
       
       if(resizeVar || resizeIn || resizeEq)
@@ -86,95 +87,102 @@ namespace tsid
       m_nin = nin;
     }
     
+    void SolverHQuadProgFast::retrieveQPData(const HQPData & problemData, const bool hessianRegularization)
+    {
+      
+      if(problemData.size() > 2)
+          {
+            assert(false && "Solver not implemented for more than 2 hierarchical levels.");
+          }
+      
+          // Compute the constraint matrix sizes
+          unsigned int neq = 0, nin = 0;
+          const ConstraintLevel & cl0 = problemData[0];
+          if(cl0.size()>0)
+          {
+            const unsigned int n = cl0[0].second->cols();
+            for(ConstraintLevel::const_iterator it=cl0.begin(); it!=cl0.end(); it++)
+            {
+              auto constr = it->second;
+              assert(n==constr->cols());
+              if(constr->isEquality())
+                neq += constr->rows();
+              else
+                nin += constr->rows();
+            }
+            // If necessary, resize the constraint matrices
+            resize(n, neq, nin);
+
+            unsigned int i_eq = 0, i_in = 0;
+            for(ConstraintLevel::const_iterator it=cl0.begin(); it!=cl0.end(); it++)
+            {
+              auto constr = it->second;
+              if(constr->isEquality())
+              {
+                m_qpData.CE.middleRows(i_eq, constr->rows()) = constr->matrix();
+                m_qpData.ce0.segment(i_eq, constr->rows())   = -constr->vector();
+                i_eq += constr->rows();
+
+              }
+              else if(constr->isInequality())
+              {
+                m_qpData.CI.middleRows(i_in, constr->rows()) = constr->matrix();
+                m_qpData.ci0.segment(i_in, constr->rows())   = -constr->lowerBound();
+                i_in += constr->rows();
+                m_qpData.CI.middleRows(i_in, constr->rows()) = -constr->matrix();
+                m_qpData.ci0.segment(i_in, constr->rows())   = constr->upperBound();
+                i_in += constr->rows();
+              }
+              else if(constr->isBound())
+              {
+                m_qpData.CI.middleRows(i_in, constr->rows()).setIdentity();
+                m_qpData.ci0.segment(i_in, constr->rows())   = -constr->lowerBound();
+                i_in += constr->rows();
+                m_qpData.CI.middleRows(i_in, constr->rows()) = -Matrix::Identity(m_n, m_n);
+                m_qpData.ci0.segment(i_in, constr->rows())   = constr->upperBound();
+                i_in += constr->rows();
+              }
+            }
+          }
+          else
+            resize(m_n, neq, nin);
+      
+          EIGEN_MALLOC_NOT_ALLOWED;
+
+          // Compute the cost 
+          if(problemData.size() > 1)
+          {
+            const ConstraintLevel & cl1 = problemData[1];
+            m_qpData.H.setZero();
+            m_qpData.g.setZero();
+        
+            for(ConstraintLevel::const_iterator it=cl1.begin(); it!=cl1.end(); it++)
+            {
+              const double & w = it->first;
+              auto constr = it->second;
+              if(!constr->isEquality())
+                assert(false && "Inequalities in the cost function are not implemented yet");
+              
+              EIGEN_MALLOC_ALLOWED;
+              m_qpData.H.noalias() += w*constr->matrix().transpose()*constr->matrix();
+              EIGEN_MALLOC_NOT_ALLOWED;
+              
+              m_qpData.g.noalias() -= w*constr->matrix().transpose()*constr->vector();
+            }
+            
+            if (hessianRegularization)
+            {
+              double m_hessian_regularization(DEFAULT_HESSIAN_REGULARIZATION);
+              m_qpData.H.diagonal().array() += m_hessian_regularization;
+            }
+          }
+    }
+
     const HQPOutput & SolverHQuadProgFast::solve(const HQPData & problemData)
     {
-      START_PROFILER_EIQUADPROG_FAST(PROFILE_EIQUADPROG_PREPARATION);
-      
-      if(problemData.size()>2)
-      {
-        assert(false && "Solver not implemented for more than 2 hierarchical levels.");
-      }
-      
-      // Compute the constraint matrix sizes
-      unsigned int neq = 0, nin = 0;
-      const ConstraintLevel & cl0 = problemData[0];
-      if(cl0.size()>0)
-      {
-        const unsigned int n = cl0[0].second->cols();
-        for(ConstraintLevel::const_iterator it=cl0.begin(); it!=cl0.end(); it++)
-        {
-          auto constr = it->second;
-          assert(n==constr->cols());
-          if(constr->isEquality())
-            neq += constr->rows();
-          else
-            nin += constr->rows();
-        }
-        // If necessary, resize the constraint matrices
-        resize(n, neq, nin);
-        
-        int i_eq=0, i_in=0;
-        for(ConstraintLevel::const_iterator it=cl0.begin(); it!=cl0.end(); it++)
-        {
-          auto constr = it->second;
-          if(constr->isEquality())
-          {
-            m_CE.middleRows(i_eq, constr->rows()) = constr->matrix();
-            m_ce0.segment(i_eq, constr->rows())   = -constr->vector();
-            i_eq += constr->rows();
-          }
-          else if(constr->isInequality())
-          {
-            m_CI.middleRows(i_in, constr->rows()) = constr->matrix();
-            m_ci0.segment(i_in, constr->rows())   = -constr->lowerBound();
-            i_in += constr->rows();
-            m_CI.middleRows(i_in, constr->rows()) = -constr->matrix();
-            m_ci0.segment(i_in, constr->rows())   = constr->upperBound();
-            i_in += constr->rows();
-          }
-          else if(constr->isBound())
-          {
-            m_CI.middleRows(i_in, constr->rows()).setIdentity();
-            m_ci0.segment(i_in, constr->rows())   = -constr->lowerBound();
-            i_in += constr->rows();
-            m_CI.middleRows(i_in, constr->rows()) = -Matrix::Identity(m_n, m_n);
-            m_ci0.segment(i_in, constr->rows())   = constr->upperBound();
-            i_in += constr->rows();
-          }
-        }
-      }
-      else
-        resize(m_n, neq, nin);
-      
-      EIGEN_MALLOC_NOT_ALLOWED;
 
-      if(problemData.size()>1)
-      {
-        const ConstraintLevel & cl1 = problemData[1];
-        m_H.setZero();
-        m_g.setZero();
-        
-        
-        for(ConstraintLevel::const_iterator it=cl1.begin(); it!=cl1.end(); it++)
-        {
-          const double & w = it->first;
-          auto constr = it->second;
-          if(!constr->isEquality())
-            assert(false && "Inequalities in the cost function are not implemented yet");
-          
-          EIGEN_MALLOC_ALLOWED;
-          m_H.noalias() += w*constr->matrix().transpose()*constr->matrix();
-          EIGEN_MALLOC_NOT_ALLOWED;
-          
-          m_g.noalias() -= w*constr->matrix().transpose()*constr->vector();
-        }
-        
-        m_H.diagonal().array() += m_hessian_regularization;
-      }
-      
-      STOP_PROFILER_EIQUADPROG_FAST(PROFILE_EIQUADPROG_PREPARATION);
-      
-      
+      SolverHQuadProgFast::retrieveQPData(problemData);
+
       START_PROFILER_EIQUADPROG_FAST(PROFILE_EIQUADPROG_SOLUTION);
       //  min 0.5 * x G x + g0 x
       //  s.t.
@@ -182,9 +190,9 @@ namespace tsid
       //  CI x + ci0 >= 0
       EIGEN_MALLOC_ALLOWED
       eiquadprog::solvers::EiquadprogFast_status
-          status = m_solver.solve_quadprog(m_H, m_g,
-                                           m_CE, m_ce0,
-                                           m_CI, m_ci0,
+          status = m_solver.solve_quadprog(m_qpData.H, m_qpData.g,
+                                           m_qpData.CE, m_qpData.ce0,
+                                           m_qpData.CI, m_qpData.ci0,
                                            m_output.x);
     
       STOP_PROFILER_EIQUADPROG_FAST(PROFILE_EIQUADPROG_SOLUTION);
@@ -199,7 +207,8 @@ namespace tsid
         m_output.activeSet = m_solver.getActiveSet().segment(m_neq, m_solver.getActiveSetSize()-m_neq);
 #ifndef NDEBUG
         const Vector & x = m_output.x;
-        
+
+        const ConstraintLevel & cl0 = problemData[0];
         if(cl0.size()>0)
         {
           for(ConstraintLevel::const_iterator it=cl0.begin(); it!=cl0.end(); it++)

--- a/src/solvers/solver-HQP-eiquadprog-fast.cpp
+++ b/src/solvers/solver-HQP-eiquadprog-fast.cpp
@@ -91,91 +91,91 @@ namespace tsid
     {
       
       if(problemData.size() > 2)
-          {
-            assert(false && "Solver not implemented for more than 2 hierarchical levels.");
-          }
-      
-          // Compute the constraint matrix sizes
-          unsigned int neq = 0, nin = 0;
-          const ConstraintLevel & cl0 = problemData[0];
-          if(cl0.size()>0)
-          {
-            const unsigned int n = cl0[0].second->cols();
-            for(ConstraintLevel::const_iterator it=cl0.begin(); it!=cl0.end(); it++)
-            {
-              auto constr = it->second;
-              assert(n==constr->cols());
-              if(constr->isEquality())
-                neq += constr->rows();
-              else
-                nin += constr->rows();
-            }
-            // If necessary, resize the constraint matrices
-            resize(n, neq, nin);
-
-            unsigned int i_eq = 0, i_in = 0;
-            for(ConstraintLevel::const_iterator it=cl0.begin(); it!=cl0.end(); it++)
-            {
-              auto constr = it->second;
-              if(constr->isEquality())
-              {
-                m_qpData.CE.middleRows(i_eq, constr->rows()) = constr->matrix();
-                m_qpData.ce0.segment(i_eq, constr->rows())   = -constr->vector();
-                i_eq += constr->rows();
-
-              }
-              else if(constr->isInequality())
-              {
-                m_qpData.CI.middleRows(i_in, constr->rows()) = constr->matrix();
-                m_qpData.ci0.segment(i_in, constr->rows())   = -constr->lowerBound();
-                i_in += constr->rows();
-                m_qpData.CI.middleRows(i_in, constr->rows()) = -constr->matrix();
-                m_qpData.ci0.segment(i_in, constr->rows())   = constr->upperBound();
-                i_in += constr->rows();
-              }
-              else if(constr->isBound())
-              {
-                m_qpData.CI.middleRows(i_in, constr->rows()).setIdentity();
-                m_qpData.ci0.segment(i_in, constr->rows())   = -constr->lowerBound();
-                i_in += constr->rows();
-                m_qpData.CI.middleRows(i_in, constr->rows()) = -Matrix::Identity(m_n, m_n);
-                m_qpData.ci0.segment(i_in, constr->rows())   = constr->upperBound();
-                i_in += constr->rows();
-              }
-            }
-          }
+      {
+        assert(false && "Solver not implemented for more than 2 hierarchical levels.");
+      }
+  
+      // Compute the constraint matrix sizes
+      unsigned int neq = 0, nin = 0;
+      const ConstraintLevel & cl0 = problemData[0];
+      if(cl0.size()>0)
+      {
+        const unsigned int n = cl0[0].second->cols();
+        for(ConstraintLevel::const_iterator it=cl0.begin(); it!=cl0.end(); it++)
+        {
+          auto constr = it->second;
+          assert(n==constr->cols());
+          if(constr->isEquality())
+            neq += constr->rows();
           else
-            resize(m_n, neq, nin);
-      
-          EIGEN_MALLOC_NOT_ALLOWED;
+            nin += constr->rows();
+        }
+        // If necessary, resize the constraint matrices
+        resize(n, neq, nin);
 
-          // Compute the cost 
-          if(problemData.size() > 1)
+        unsigned int i_eq = 0, i_in = 0;
+        for(ConstraintLevel::const_iterator it=cl0.begin(); it!=cl0.end(); it++)
+        {
+          auto constr = it->second;
+          if(constr->isEquality())
           {
-            const ConstraintLevel & cl1 = problemData[1];
-            m_qpData.H.setZero();
-            m_qpData.g.setZero();
-        
-            for(ConstraintLevel::const_iterator it=cl1.begin(); it!=cl1.end(); it++)
-            {
-              const double & w = it->first;
-              auto constr = it->second;
-              if(!constr->isEquality())
-                assert(false && "Inequalities in the cost function are not implemented yet");
-              
-              EIGEN_MALLOC_ALLOWED;
-              m_qpData.H.noalias() += w*constr->matrix().transpose()*constr->matrix();
-              EIGEN_MALLOC_NOT_ALLOWED;
-              
-              m_qpData.g.noalias() -= w*constr->matrix().transpose()*constr->vector();
-            }
-            
-            if (hessianRegularization)
-            {
-              double m_hessian_regularization(DEFAULT_HESSIAN_REGULARIZATION);
-              m_qpData.H.diagonal().array() += m_hessian_regularization;
-            }
+            m_qpData.CE.middleRows(i_eq, constr->rows()) = constr->matrix();
+            m_qpData.ce0.segment(i_eq, constr->rows())   = -constr->vector();
+            i_eq += constr->rows();
+
           }
+          else if(constr->isInequality())
+          {
+            m_qpData.CI.middleRows(i_in, constr->rows()) = constr->matrix();
+            m_qpData.ci0.segment(i_in, constr->rows())   = -constr->lowerBound();
+            i_in += constr->rows();
+            m_qpData.CI.middleRows(i_in, constr->rows()) = -constr->matrix();
+            m_qpData.ci0.segment(i_in, constr->rows())   = constr->upperBound();
+            i_in += constr->rows();
+          }
+          else if(constr->isBound())
+          {
+            m_qpData.CI.middleRows(i_in, constr->rows()).setIdentity();
+            m_qpData.ci0.segment(i_in, constr->rows())   = -constr->lowerBound();
+            i_in += constr->rows();
+            m_qpData.CI.middleRows(i_in, constr->rows()) = -Matrix::Identity(m_n, m_n);
+            m_qpData.ci0.segment(i_in, constr->rows())   = constr->upperBound();
+            i_in += constr->rows();
+          }
+        }
+      }
+      else
+        resize(m_n, neq, nin);
+  
+      EIGEN_MALLOC_NOT_ALLOWED;
+
+      // Compute the cost 
+      if(problemData.size() > 1)
+      {
+        const ConstraintLevel & cl1 = problemData[1];
+        m_qpData.H.setZero();
+        m_qpData.g.setZero();
+    
+        for(ConstraintLevel::const_iterator it=cl1.begin(); it!=cl1.end(); it++)
+        {
+          const double & w = it->first;
+          auto constr = it->second;
+          if(!constr->isEquality())
+            assert(false && "Inequalities in the cost function are not implemented yet");
+          
+          EIGEN_MALLOC_ALLOWED;
+          m_qpData.H.noalias() += w*constr->matrix().transpose()*constr->matrix();
+          EIGEN_MALLOC_NOT_ALLOWED;
+          
+          m_qpData.g.noalias() -= w*constr->matrix().transpose()*constr->vector();
+        }
+        
+        if (hessianRegularization)
+        {
+          double m_hessian_regularization(DEFAULT_HESSIAN_REGULARIZATION);
+          m_qpData.H.diagonal().array() += m_hessian_regularization;
+        }
+      }
     }
 
     const HQPOutput & SolverHQuadProgFast::solve(const HQPData & problemData)

--- a/src/solvers/solver-HQP-eiquadprog.cpp
+++ b/src/solvers/solver-HQP-eiquadprog.cpp
@@ -75,7 +75,7 @@ void SolverHQuadProg::resize(unsigned int n, unsigned int neq, unsigned int nin)
   m_nin = nin;
 }
 
-void SolverHQuadProg::retrieveQPData(const HQPData & problemData, const bool hessianRegularization)
+void SolverHQuadProg::retrieveQPData(const HQPData & problemData, const bool /*hessianRegularization*/)
 {
   if(problemData.size()>2)
   {
@@ -260,7 +260,7 @@ const HQPOutput & SolverHQuadProg::solve(const HQPData & problemData)
     m_output.status = HQP_STATUS_OPTIMAL;
 #ifndef NDEBUG
     const Vector & x = m_output.x;
-
+    const ConstraintLevel & cl0 = problemData[0];
     if(cl0.size()>0)
     {
       for(ConstraintLevel::const_iterator it=cl0.begin(); it!=cl0.end(); it++)

--- a/src/solvers/solver-HQP-factory.cpp
+++ b/src/solvers/solver-HQP-factory.cpp
@@ -26,6 +26,11 @@
 #ifdef TSID_PROXSUITE_FOUND
   #include <tsid/solvers/solver-proxqp.hpp>
 #endif
+
+#ifdef TSID_OSQP_FOUND
+  #include <tsid/solvers/solver-osqp.hpp>
+#endif
+
 #ifdef QPOASES_FOUND
   #include <tsid/solvers/solver-HQP-qpoases.hh>
 #endif
@@ -53,6 +58,12 @@ namespace tsid
       if(solverType==SOLVER_HQP_PROXSUITE)
         return new SolverProxQP(name);
 #endif
+
+#ifdef TSID_OSQP_FOUND
+      if(solverType==SOLVER_HQP_OSQP)
+        return new SolverOSQP(name);
+#endif
+
 #ifdef QPOASES_FOUND
       if(solverType==SOLVER_HQP_QPOASES)
         return new Solver_HQP_qpoases(name);

--- a/src/solvers/solver-HQP-factory.cpp
+++ b/src/solvers/solver-HQP-factory.cpp
@@ -55,7 +55,7 @@ namespace tsid
 #endif
 
 #ifdef TSID_PROXSUITE_FOUND
-      if(solverType==SOLVER_HQP_PROXSUITE)
+      if(solverType==SOLVER_HQP_PROXQP)
         return new SolverProxQP(name);
 #endif
 

--- a/src/solvers/solver-HQP-factory.cpp
+++ b/src/solvers/solver-HQP-factory.cpp
@@ -23,6 +23,9 @@
   #include <tsid/solvers/solver-HQP-qpmad.hpp>
 #endif
 
+#ifdef TSID_PROXSUITE_FOUND
+  #include <tsid/solvers/solver-proxqp.hpp>
+#endif
 #ifdef QPOASES_FOUND
   #include <tsid/solvers/solver-HQP-qpoases.hh>
 #endif
@@ -46,6 +49,10 @@ namespace tsid
         return new SolverHQpmad(name);
 #endif
 
+#ifdef TSID_PROXSUITE_FOUND
+      if(solverType==SOLVER_HQP_PROXSUITE)
+        return new SolverProxQP(name);
+#endif
 #ifdef QPOASES_FOUND
       if(solverType==SOLVER_HQP_QPOASES)
         return new Solver_HQP_qpoases(name);

--- a/src/solvers/solver-HQP-factory.cpp
+++ b/src/solvers/solver-HQP-factory.cpp
@@ -23,11 +23,11 @@
   #include <tsid/solvers/solver-HQP-qpmad.hpp>
 #endif
 
-#ifdef TSID_PROXSUITE_FOUND
+#ifdef TSID_WITH_PROXSUITE
   #include <tsid/solvers/solver-proxqp.hpp>
 #endif
 
-#ifdef TSID_OSQP_FOUND
+#ifdef TSID_WITH_OSQP
   #include <tsid/solvers/solver-osqp.hpp>
 #endif
 
@@ -54,12 +54,12 @@ namespace tsid
         return new SolverHQpmad(name);
 #endif
 
-#ifdef TSID_PROXSUITE_FOUND
+#ifdef TSID_WITH_PROXSUITE
       if(solverType==SOLVER_HQP_PROXQP)
         return new SolverProxQP(name);
 #endif
 
-#ifdef TSID_OSQP_FOUND
+#ifdef TSID_WITH_OSQP
       if(solverType==SOLVER_HQP_OSQP)
         return new SolverOSQP(name);
 #endif

--- a/src/solvers/solver-osqp.cpp
+++ b/src/solvers/solver-osqp.cpp
@@ -210,7 +210,7 @@ namespace tsid
 
       SolverOSQP::retrieveQPData(problemData);
 
-      START_PROFILER("PROFILE_OSQP_SOLUTION");
+      START_PROFILER_OSQP("PROFILE_OSQP_SOLUTION");
       //  min 0.5 * x G x + g0 x
       //  s.t.
       //  lb <= CI x <= ub (including equality constraints)
@@ -238,7 +238,7 @@ namespace tsid
         m_solver.initSolver();
       }
       m_solver.solveProblem();
-      STOP_PROFILER("PROFILE_OSQP_SOLUTION");
+      STOP_PROFILER_OSQP("PROFILE_OSQP_SOLUTION");
       
       OsqpEigen::Status status = m_solver.getStatus();
 

--- a/src/solvers/solver-osqp.cpp
+++ b/src/solvers/solver-osqp.cpp
@@ -1,0 +1,346 @@
+//
+// Copyright (c) 2022 INRIA
+//
+// This file is part of tsid
+// tsid is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+// tsid is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Lesser Public License for more details. You should have
+// received a copy of the GNU Lesser General Public License along with
+// tsid If not, see
+// <http://www.gnu.org/licenses/>.
+//
+
+#include "tsid/solvers/solver-osqp.hpp"
+#include "tsid/math/utils.hpp"
+#include "tsid/utils/stop-watch.hpp"
+
+namespace tsid
+{
+  namespace solvers
+  {
+    
+    using namespace math;
+    SolverOSQP::SolverOSQP(const std::string & name):
+    SolverHQPBase(name),
+    m_hessian_regularization(DEFAULT_HESSIAN_REGULARIZATION)
+    {
+      m_n = 0;
+      m_neq = 0;
+      m_nin = 0;
+      m_rho = 0.1;
+      m_sigma = 1e-6;
+      m_alpha = 1.6;
+      m_epsAbs = 1e-5;
+      m_epsRel = 0.;
+      m_isVerbose = false;
+      m_isDataInitialized = false;
+    }
+
+    SolverOSQP::SolverOSQP(const SolverOSQP & other):
+    SolverHQPBase(other.name()),
+    m_hessian_regularization(other.m_hessian_regularization)
+    {
+      m_n = other.m_n;
+      m_neq = other.m_neq;
+      m_nin = other.m_nin;
+      m_rho = other.m_rho;
+      m_sigma = other.m_sigma;
+      m_alpha = other.m_alpha;
+      m_epsAbs = other.m_epsAbs;
+      m_epsRel = other.m_epsRel;
+      m_isVerbose = other.m_isVerbose;
+      m_isDataInitialized = other.m_isDataInitialized;
+    }
+
+    void SolverOSQP::sendMsg(const std::string & s)
+    {
+      std::cout<<"[SolverOSQP."<<m_name<<"] "<<s<<std::endl;
+    }
+    
+    void SolverOSQP::resize(unsigned int n, unsigned int neq, unsigned int nin)
+    {
+      const bool resizeVar = n!=m_n;
+      const bool resizeEq = (resizeVar || neq!=m_neq );
+      const bool resizeIn = (resizeVar || nin!=m_nin );
+
+      if(resizeIn || resizeEq)
+      {
+        m_qpData.CI.resize(nin + neq, n);
+        m_qpData.ci_lb.resize(nin + neq);
+        m_qpData.ci_ub.resize(nin + neq);
+      }
+      if(resizeVar)
+      {
+    #ifndef NDEBUG
+        sendMsg("Resizing Hessian from "+toString(m_n)+" to "+toString(n));
+    #endif
+        m_qpData.H.resize(n, n);
+        m_qpData.g.resize(n);
+        m_output.x.resize(n);
+      }
+
+      m_n = n;
+      m_neq = neq;
+      m_nin = nin;
+
+      if (resizeVar || resizeEq || resizeIn)
+      {
+        if(m_solver.isInitialized())
+        {
+          m_solver.clearSolverVariables();
+          m_solver.data()->clearHessianMatrix();
+          m_solver.data()->clearLinearConstraintsMatrix();
+          m_solver.clearSolver();
+        }
+        m_solver.data()->setNumberOfVariables(int(m_n));
+        m_solver.data()->setNumberOfConstraints(int(m_neq + m_nin));
+
+        m_isDataInitialized = false;
+    #ifndef NDEBUG
+        setVerbose(true);
+    #endif
+        setMaximumIterations(m_maxIter);
+        setSigma(m_sigma);
+        setAlpha(m_alpha);
+        setRho(m_rho);
+        setEpsilonAbsolute(m_epsAbs);
+        setEpsilonRelative(m_epsRel);
+        setVerbose(m_isVerbose);
+      }
+    }
+
+    void SolverOSQP::retrieveQPData(const HQPData & problemData, const bool hessianRegularization)
+    {
+
+      if(problemData.size() > 2)
+          {
+            assert(false && "Solver not implemented for more than 2 hierarchical levels.");
+          }
+          
+          // Compute the constraint matrix sizes
+          unsigned int neq = 0, nin = 0;
+          const ConstraintLevel & cl0 = problemData[0];
+
+          if(cl0.size()>0)
+          {
+            const unsigned int n = cl0[0].second->cols();
+            for(ConstraintLevel::const_iterator it=cl0.begin(); it!=cl0.end(); it++)
+            {
+              auto constr = it->second;
+              assert(n==constr->cols());
+              if(constr->isEquality())
+                neq += constr->rows();
+              else
+                nin += constr->rows();
+            }
+            // If necessary, resize the constraint matrices
+            resize(n, neq, nin);
+            
+            unsigned int i_in = 0;
+            for(ConstraintLevel::const_iterator it=cl0.begin(); it!=cl0.end(); it++)
+            {
+              auto constr = it->second;
+              if(constr->isEquality())
+              {
+                m_qpData.CI.middleRows(i_in, constr->rows()) = constr->matrix();
+                m_qpData.ci_lb.segment(i_in, constr->rows()) = constr->vector();
+                m_qpData.ci_ub.segment(i_in, constr->rows()) = constr->vector();
+                i_in += constr->rows();
+              }
+              else if(constr->isInequality())
+              {
+                m_qpData.CI.middleRows(i_in, constr->rows()) = constr->matrix();
+                m_qpData.ci_lb.segment(i_in, constr->rows()) = constr->lowerBound();
+                m_qpData.ci_ub.segment(i_in, constr->rows()) = constr->upperBound();
+                i_in += constr->rows();
+              }
+              else if(constr->isBound())
+              {
+                m_qpData.CI.middleRows(i_in, constr->rows()).setIdentity();
+                m_qpData.ci_lb.segment(i_in, constr->rows()) = constr->lowerBound();
+                m_qpData.ci_ub.segment(i_in, constr->rows()) = constr->upperBound();
+                i_in += constr->rows();
+              }
+            }
+          }
+          else
+          {
+            resize(m_n, neq, nin);
+          }
+          
+          EIGEN_MALLOC_NOT_ALLOWED;
+
+          // Compute the cost 
+          if(problemData.size() > 1)
+          {
+            const ConstraintLevel & cl1 = problemData[1];
+            m_qpData.H.setZero();
+            m_qpData.g.setZero();
+            
+            for(ConstraintLevel::const_iterator it=cl1.begin(); it!=cl1.end(); it++)
+            {
+              const double & w = it->first;
+              auto constr = it->second;
+              if(!constr->isEquality())
+                assert(false && "Inequalities in the cost function are not implemented yet");
+              
+              EIGEN_MALLOC_ALLOWED;
+              m_qpData.H.noalias() += w*constr->matrix().transpose()*constr->matrix();
+              EIGEN_MALLOC_NOT_ALLOWED;
+              
+              m_qpData.g.noalias() -= w*constr->matrix().transpose()*constr->vector();
+            }
+            
+            if (hessianRegularization)
+            {
+              double m_hessian_regularization(DEFAULT_HESSIAN_REGULARIZATION);
+              m_qpData.H.diagonal().array() += m_hessian_regularization;
+            }
+          }
+    }
+  
+    const HQPOutput & SolverOSQP::solve(const HQPData & problemData)
+    {
+      typedef Eigen::SparseMatrix<double> SpMat;
+
+      SolverOSQP::retrieveQPData(problemData);
+
+      START_PROFILER("PROFILE_OSQP_SOLUTION");
+      //  min 0.5 * x G x + g0 x
+      //  s.t.
+      //  lb <= CI x <= ub (including equality constraints)
+
+      EIGEN_MALLOC_ALLOWED
+
+      if (!m_isDataInitialized)
+      {
+        m_solver.data()->setHessianMatrix(static_cast<SpMat>(m_qpData.H.sparseView()));
+        m_solver.data()->setGradient(m_qpData.g);
+        m_solver.data()->setLinearConstraintsMatrix(static_cast<SpMat>(m_qpData.CI.sparseView()));
+        m_solver.data()->setBounds(m_qpData.ci_lb, m_qpData.ci_ub);
+        m_isDataInitialized = true;
+      }
+      else
+      {
+        m_solver.updateHessianMatrix(static_cast<SpMat>(m_qpData.H.sparseView()));
+        m_solver.updateGradient(m_qpData.g);
+        m_solver.updateLinearConstraintsMatrix(static_cast<SpMat>(m_qpData.CI.sparseView()));
+        m_solver.updateBounds(m_qpData.ci_lb, m_qpData.ci_ub);
+      }
+      
+      if (!m_solver.isInitialized())
+      {
+        m_solver.initSolver();
+      }
+      m_solver.solveProblem();
+      STOP_PROFILER("PROFILE_OSQP_SOLUTION");
+      
+      OsqpEigen::Status status = m_solver.getStatus();
+
+      if(status == OsqpEigen::Status::Solved)
+      {
+        m_output.x = m_solver.getSolution();
+        m_output.status = HQP_STATUS_OPTIMAL;
+        m_output.lambda = m_solver.getDualSolution();
+
+#ifndef NDEBUG
+        const Vector & x = m_solver.getSolution();
+
+        const ConstraintLevel & cl0 = problemData[0];
+
+        if(cl0.size()>0)
+        {
+          for(ConstraintLevel::const_iterator it=cl0.begin(); it!=cl0.end(); it++)
+          {
+            auto constr = it->second;
+            if(constr->checkConstraint(x)==false)
+            {
+              // m_output.status = HQP_STATUS_ERROR;
+              if(constr->isEquality())
+              {
+                sendMsg("Equality "+constr->name()+" violated: "+
+                        toString((constr->matrix()*x-constr->vector()).norm()));
+              }
+              else if(constr->isInequality())
+              {
+                sendMsg("Inequality "+constr->name()+" violated: "+
+                        toString((constr->matrix()*x-constr->lowerBound()).minCoeff())+"\n"+
+                        toString((constr->upperBound()-constr->matrix()*x).minCoeff()));
+              }
+              else if(constr->isBound())
+              {
+                sendMsg("Bound "+constr->name()+" violated: "+
+                        toString((x-constr->lowerBound()).minCoeff())+"\n"+
+                        toString((constr->upperBound()-x).minCoeff()));
+              }
+            }
+          }
+        }
+#endif
+      }
+      else if(status==OsqpEigen::Status::PrimalInfeasible)
+        m_output.status = HQP_STATUS_INFEASIBLE;
+      else if(status==OsqpEigen::Status::MaxIterReached)
+        m_output.status = HQP_STATUS_MAX_ITER_REACHED;
+      else if(status==OsqpEigen::Status::DualInfeasible)
+        m_output.status = HQP_STATUS_INFEASIBLE;
+      else if(status==OsqpEigen::Status::SolvedInaccurate)
+        m_output.status = HQP_STATUS_MAX_ITER_REACHED;
+      else
+        m_output.status = HQP_STATUS_UNKNOWN;
+      
+      return m_output;
+    }
+    
+    double SolverOSQP::getObjectiveValue()
+    {
+      return m_solver.getObjValue();
+    }
+    
+    bool SolverOSQP::setMaximumIterations(unsigned int maxIter)
+    {
+      SolverHQPBase::setMaximumIterations(maxIter);
+      m_solver.settings()->setMaxIteration(int(maxIter));
+      return true;
+    }
+
+    void SolverOSQP::setSigma(double sigma)
+    {
+      m_sigma = sigma;
+      m_solver.settings()->setSigma(m_sigma);
+    }
+    void SolverOSQP::setAlpha(double alpha)
+    {
+      m_alpha = alpha;
+      m_solver.settings()->setAlpha(m_alpha);
+    }
+
+    void SolverOSQP::setRho(double rho)
+    {
+      m_rho = rho;
+      m_solver.settings()->setRho(m_rho);
+    }
+    void SolverOSQP::setEpsilonAbsolute(double epsAbs)
+    {
+      m_epsAbs = epsAbs;
+      m_solver.settings()->setAbsoluteTolerance(m_epsAbs);
+    }
+    void SolverOSQP::setEpsilonRelative(double epsRel)
+    {
+      m_epsRel = epsRel;
+      m_solver.settings()->setRelativeTolerance(m_epsRel);
+    }
+    void SolverOSQP::setVerbose(bool isVerbose)
+    {
+      m_isVerbose = isVerbose;
+      m_solver.settings()->setVerbosity(m_isVerbose);
+    }
+  }
+}
+
+

--- a/src/solvers/solver-proxqp.cpp
+++ b/src/solvers/solver-proxqp.cpp
@@ -1,0 +1,310 @@
+//
+// Copyright (c) 2022 INRIA
+//
+// This file is part of tsid
+// tsid is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+// tsid is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Lesser Public License for more details. You should have
+// received a copy of the GNU Lesser General Public License along with
+// tsid If not, see
+// <http://www.gnu.org/licenses/>.
+//
+
+#include "tsid/solvers/solver-proxqp.hpp"
+#include "tsid/math/utils.hpp"
+#include "tsid/utils/stop-watch.hpp"
+
+namespace tsid
+{
+  namespace solvers
+  {
+    
+    using namespace math;
+    SolverProxQP::SolverProxQP(const std::string & name):
+    SolverHQPBase(name),
+    m_hessian_regularization(DEFAULT_HESSIAN_REGULARIZATION),
+    m_solver(1, 0, 0)  // dim of primal var needs to be strictly positiv
+    {
+      m_n = 0;
+      m_neq = 0;
+      m_nin = 0;
+      m_rho = 1e-6;
+      m_muIn = 1e-1;
+      m_muEq = 1e-3;
+      m_epsAbs = 1e-5;
+      m_epsRel = 0.;
+      m_isVerbose = false;
+    }
+    
+    void SolverProxQP::sendMsg(const std::string & s)
+    {
+      std::cout<<"[SolverProxQP."<<m_name<<"] "<<s<<std::endl;
+    }
+    
+    void SolverProxQP::resize(unsigned int n, unsigned int neq, unsigned int nin)
+    {
+      const bool resizeVar = n!=m_n;
+      const bool resizeEq = (resizeVar || neq!=m_neq );
+      const bool resizeIn = (resizeVar || nin!=m_nin );
+
+      if(resizeEq)
+      {
+    #ifndef NDEBUG
+        sendMsg("Resizing equality constraints from "+toString(m_neq)+" to "+toString(neq));
+    #endif
+        m_qpData.CE.resize(neq, n);
+        m_qpData.ce0.resize(neq);
+      }
+      if(resizeIn)
+      {
+    #ifndef NDEBUG
+        sendMsg("Resizing inequality constraints from "+toString(m_nin)+" to "+toString(nin));
+    #endif
+        m_qpData.CI.resize(nin, n);
+        m_qpData.ci_lb.resize(nin);
+        m_qpData.ci_ub.resize(nin);
+      }
+      if(resizeVar)
+      {
+    #ifndef NDEBUG
+        sendMsg("Resizing Hessian from "+toString(m_n)+" to "+toString(n));
+    #endif
+        m_qpData.H.resize(n, n);
+        m_qpData.g.resize(n);
+        m_output.x.resize(n);
+      }
+
+      m_n = n;
+      m_neq = neq;
+      m_nin = nin;
+
+      if (resizeVar || resizeEq || resizeIn)
+      {
+        m_solver = dense::QP<double>(m_n, m_neq, m_nin);
+        setMaximumIterations(m_maxIter);
+        setMuInequality(m_muIn);
+        setMuEquality(m_muEq);
+        setRho(m_rho);
+        setEpsilonAbsolute(m_epsAbs);
+        setEpsilonRelative(m_epsRel);
+        setVerbose(m_isVerbose);
+    #ifndef NDEBUG
+        setVerbose(true);
+    #endif
+      }
+    }
+
+    void SolverProxQP::retrieveQPData(const HQPData & problemData, const bool hessianRegularization)
+    {
+
+      if(problemData.size() > 2)
+          {
+            assert(false && "Solver not implemented for more than 2 hierarchical levels.");
+          }
+          
+          // Compute the constraint matrix sizes
+          unsigned int neq = 0, nin = 0;
+          const ConstraintLevel & cl0 = problemData[0];
+
+          if(cl0.size()>0)
+          {
+            const unsigned int n = cl0[0].second->cols();
+            for(ConstraintLevel::const_iterator it=cl0.begin(); it!=cl0.end(); it++)
+            {
+              auto constr = it->second;
+              assert(n==constr->cols());
+              if(constr->isEquality())
+                neq += constr->rows();
+              else
+                nin += constr->rows();
+            }
+            // If necessary, resize the constraint matrices
+            resize(n, neq, nin);
+            
+            unsigned int i_eq = 0, i_in = 0;
+            for(ConstraintLevel::const_iterator it=cl0.begin(); it!=cl0.end(); it++)
+            {
+              auto constr = it->second;
+              if(constr->isEquality())
+              {
+                m_qpData.CE.middleRows(i_eq, constr->rows()) = constr->matrix();
+                m_qpData.ce0.segment(i_eq, constr->rows())   = constr->vector();
+                i_eq += constr->rows();
+              }
+              else if(constr->isInequality())
+              {
+                m_qpData.CI.middleRows(i_in, constr->rows()) = constr->matrix();
+                m_qpData.ci_lb.segment(i_in, constr->rows()) = constr->lowerBound();
+                m_qpData.ci_ub.segment(i_in, constr->rows()) = constr->upperBound();
+                i_in += constr->rows();
+              }
+              else if(constr->isBound())
+              {
+                m_qpData.CI.middleRows(i_in, constr->rows()).setIdentity();
+                m_qpData.ci_lb.segment(i_in, constr->rows()) = constr->lowerBound();
+                m_qpData.ci_ub.segment(i_in, constr->rows()) = constr->upperBound();
+                i_in += constr->rows();
+              }
+            }
+          }
+          else
+          {
+            resize(m_n, neq, nin);
+          }
+          
+          EIGEN_MALLOC_NOT_ALLOWED;
+
+          // Compute the cost 
+          if(problemData.size() > 1)
+          {
+            const ConstraintLevel & cl1 = problemData[1];
+            m_qpData.H.setZero();
+            m_qpData.g.setZero();
+            
+            for(ConstraintLevel::const_iterator it=cl1.begin(); it!=cl1.end(); it++)
+            {
+              const double & w = it->first;
+              auto constr = it->second;
+              if(!constr->isEquality())
+                assert(false && "Inequalities in the cost function are not implemented yet");
+              
+              EIGEN_MALLOC_ALLOWED;
+              m_qpData.H.noalias() += w*constr->matrix().transpose()*constr->matrix();
+              EIGEN_MALLOC_NOT_ALLOWED;
+              
+              m_qpData.g.noalias() -= w*constr->matrix().transpose()*constr->vector();
+            }
+            
+            if (hessianRegularization)
+            {
+              double m_hessian_regularization(DEFAULT_HESSIAN_REGULARIZATION);
+              m_qpData.H.diagonal().array() += m_hessian_regularization;
+            }
+          }
+    }
+  
+    const HQPOutput & SolverProxQP::solve(const HQPData & problemData)
+    {
+
+      SolverProxQP::retrieveQPData(problemData);
+
+      START_PROFILER("PROFILE_PROXQP_SOLUTION");
+      //  min 0.5 * x^T H x + g^T x
+      //  s.t.
+      //  CE x + ce0 = 0
+      //  ci_lb <= CI x <= ci_ub
+
+      EIGEN_MALLOC_ALLOWED
+
+      m_solver.init(m_qpData.H, m_qpData.g,
+                     m_qpData.CE, m_qpData.ce0,
+                     m_qpData.CI, m_qpData.ci_ub, m_qpData.ci_lb);
+
+      m_solver.solve();
+      STOP_PROFILER("PROFILE_PROXQP_SOLUTION");
+      
+      QPSolverOutput status = m_solver.results.info.status;
+      
+      if(status == QPSolverOutput::PROXQP_SOLVED)
+      {
+        m_output.x = m_solver.results.x;
+        m_output.status = HQP_STATUS_OPTIMAL;
+        m_output.lambda = m_solver.results.y;
+        m_output.iterations = int(m_solver.results.info.iter);
+        m_output.activeSet.setZero();
+
+#ifndef NDEBUG
+        const Vector & x = m_solver.results.x;
+
+        const ConstraintLevel & cl0 = problemData[0];
+
+        if(cl0.size()>0)
+        {
+          for(ConstraintLevel::const_iterator it=cl0.begin(); it!=cl0.end(); it++)
+          {
+            auto constr = it->second;
+            if(constr->checkConstraint(x)==false)
+            {
+              if(constr->isEquality())
+              {
+                sendMsg("Equality "+constr->name()+" violated: "+
+                        toString((constr->matrix()*x-constr->vector()).norm()));
+              }
+              else if(constr->isInequality())
+              {
+                sendMsg("Inequality "+constr->name()+" violated: "+
+                        toString((constr->matrix()*x-constr->lowerBound()).minCoeff())+"\n"+
+                        toString((constr->upperBound()-constr->matrix()*x).minCoeff()));
+              }
+              else if(constr->isBound())
+              {
+                sendMsg("Bound "+constr->name()+" violated: "+
+                        toString((x-constr->lowerBound()).minCoeff())+"\n"+
+                        toString((constr->upperBound()-x).minCoeff()));
+              }
+            }
+          }
+        }
+#endif
+      }
+      else if(status==QPSolverOutput::PROXQP_PRIMAL_INFEASIBLE)
+        m_output.status = HQP_STATUS_INFEASIBLE;
+      else if(status==QPSolverOutput::PROXQP_MAX_ITER_REACHED)
+        m_output.status = HQP_STATUS_MAX_ITER_REACHED;
+      else if(status==QPSolverOutput::PROXQP_DUAL_INFEASIBLE)
+        m_output.status = HQP_STATUS_INFEASIBLE;
+      
+      return m_output;
+    }
+    
+    double SolverProxQP::getObjectiveValue()
+    {
+      return m_solver.results.info.objValue;
+    }
+    
+    bool SolverProxQP::setMaximumIterations(unsigned int maxIter)
+    {
+      SolverHQPBase::setMaximumIterations(maxIter);
+      m_solver.settings.max_iter = maxIter;
+      return true;
+    }
+
+    void SolverProxQP::setMuInequality(double muIn)
+    {
+      m_muIn = muIn;
+      m_solver.settings.default_mu_in = m_muIn;
+    }
+    void SolverProxQP::setMuEquality(double muEq)
+    {
+      m_muEq = muEq;
+      m_solver.settings.default_mu_eq = m_muEq;
+    }
+    void SolverProxQP::setRho(double rho)
+    {
+      m_rho = rho;
+      m_solver.settings.default_rho = m_rho;
+    }
+    void SolverProxQP::setEpsilonAbsolute(double epsAbs)
+    {
+      m_epsAbs = epsAbs;
+      m_solver.settings.eps_abs = m_epsAbs;
+    }
+    void SolverProxQP::setEpsilonRelative(double epsRel)
+    {
+      m_epsRel = epsRel;
+      m_solver.settings.eps_rel = m_epsRel;
+    }
+    void SolverProxQP::setVerbose(bool isVerbose)
+    {
+      m_isVerbose = isVerbose;
+      m_solver.settings.verbose = m_isVerbose;
+    }
+  }
+}
+
+

--- a/src/solvers/solver-proxqp.cpp
+++ b/src/solvers/solver-proxqp.cpp
@@ -193,7 +193,7 @@ namespace tsid
 
       SolverProxQP::retrieveQPData(problemData);
 
-      START_PROFILER("PROFILE_PROXQP_SOLUTION");
+      START_PROFILER_PROXQP("PROFILE_PROXQP_SOLUTION");
       //  min 0.5 * x^T H x + g^T x
       //  s.t.
       //  CE x + ce0 = 0
@@ -206,7 +206,7 @@ namespace tsid
                      m_qpData.CI, m_qpData.ci_ub, m_qpData.ci_lb);
 
       m_solver.solve();
-      STOP_PROFILER("PROFILE_PROXQP_SOLUTION");
+      STOP_PROFILER_PROXQP("PROFILE_PROXQP_SOLUTION");
       
       QPSolverOutput status = m_solver.results.info.status;
       

--- a/src/solvers/solver-proxqp.cpp
+++ b/src/solvers/solver-proxqp.cpp
@@ -203,7 +203,7 @@ namespace tsid
 
       m_solver.init(m_qpData.H, m_qpData.g,
                      m_qpData.CE, m_qpData.ce0,
-                     m_qpData.CI, m_qpData.ci_ub, m_qpData.ci_lb);
+                     m_qpData.CI, m_qpData.ci_lb, m_qpData.ci_ub);
 
       m_solver.solve();
       STOP_PROFILER_PROXQP("PROFILE_PROXQP_SOLUTION");

--- a/src/tasks/task-cop-equality.cpp
+++ b/src/tasks/task-cop-equality.cpp
@@ -77,7 +77,7 @@ const ConstraintBase & TaskCopEquality::compute(const double,
   M.resize(3, n);
   for(auto& cl : *m_contacts)
   {
-    int i = cl->index;
+    unsigned int i = cl->index;
     // get contact points in local frame and transform them to world frame
     const Matrix3x &P = cl->contact.getContactPoints();
     m_robot.framePosition(data, cl->contact.getMotionTask().frame_id(), oMi);

--- a/tests/hqp_solvers.cpp
+++ b/tests/hqp_solvers.cpp
@@ -24,10 +24,10 @@
 #include <tsid/solvers/solver-HQP-eiquadprog.hpp>
 #include <tsid/solvers/solver-HQP-eiquadprog-rt.hpp>
 
-#ifdef TSID_PROXSUITE_FOUND
+#ifdef TSID_WITH_PROXSUITE
   #include <tsid/solvers/solver-proxqp.hpp>
 #endif
-#ifdef TSID_OSQP_FOUND
+#ifdef TSID_WITH_OSQP
   #include <tsid/solvers/solver-osqp.hpp>
 #endif
 #ifdef TSID_QPMAD_FOUND
@@ -224,12 +224,12 @@ BOOST_AUTO_TEST_CASE ( test_eiquadprog_classic_vs_rt_vs_fast_vs_proxqp)
                                                              "eiquadprog");
   solver->resize(n, neq, nin);
 
-#ifdef TSID_PROXSUITE_FOUND
+#ifdef TSID_WITH_PROXSUITE
   SolverHQPBase * solver_proxqp = SolverHQPFactory::createNewSolver(SOLVER_HQP_PROXQP,
                                                              "proxqp");
 #endif
 
-#ifdef TSID_OSQP_FOUND
+#ifdef TSID_WITH_OSQP
   SolverHQPBase * solver_osqp = SolverHQPFactory::createNewSolver(SOLVER_HQP_OSQP,
                                                              "osqp");
 #endif
@@ -306,13 +306,13 @@ BOOST_AUTO_TEST_CASE ( test_eiquadprog_classic_vs_rt_vs_fast_vs_proxqp)
     const HQPOutput & output    = solver->solve(HQPData);
     getProfiler().stop(PROFILE_EIQUADPROG);
 
-  #ifdef TSID_PROXSUITE_FOUND
+  #ifdef TSID_WITH_PROXSUITE
     getProfiler().start(PROFILE_PROXQP);
     const HQPOutput & output_proxqp = solver_proxqp->solve(HQPData);
     getProfiler().stop(PROFILE_PROXQP);
   #endif
 
-  #ifdef TSID_OSQP_FOUND
+  #ifdef TSID_WITH_OSQP
     getProfiler().start(PROFILE_OSQP);
     const HQPOutput & output_osqp = solver_osqp->solve(HQPData);
     getProfiler().stop(PROFILE_OSQP);
@@ -338,13 +338,13 @@ BOOST_AUTO_TEST_CASE ( test_eiquadprog_classic_vs_rt_vs_fast_vs_proxqp)
       const HQPOutput & output    = solver->solve(HQPData);
       getProfiler().stop(PROFILE_EIQUADPROG);
 
-    #ifdef TSID_PROXSUITE_FOUND
+    #ifdef TSID_WITH_PROXSUITE
       getProfiler().start(PROFILE_PROXQP);
       const HQPOutput & output_proxqp = solver_proxqp->solve(HQPData);
       getProfiler().stop(PROFILE_PROXQP);
     #endif
 
-    #ifdef TSID_OSQP_FOUND
+    #ifdef TSID_WITH_OSQP
       getProfiler().start(PROFILE_OSQP);
       const HQPOutput & output_osqp = solver_osqp->solve(HQPData);
       getProfiler().stop(PROFILE_OSQP);
@@ -367,12 +367,12 @@ BOOST_AUTO_TEST_CASE ( test_eiquadprog_classic_vs_rt_vs_fast_vs_proxqp)
                           "Status "+SolverHQPBase::HQP_status_string[output.status]+
                           " Status FAST "+SolverHQPBase::HQP_status_string[output_fast.status]);
 
-  #ifdef TSID_PROXSUITE_FOUND
+  #ifdef TSID_WITH_PROXSUITE
     BOOST_REQUIRE_MESSAGE(output.status==output_proxqp.status,
                           "Status "+SolverHQPBase::HQP_status_string[output.status]+
                           " Status Proxqp "+SolverHQPBase::HQP_status_string[output_proxqp.status]);
   #endif
-  #ifdef TSID_OSQP_FOUND
+  #ifdef TSID_WITH_OSQP
     BOOST_REQUIRE_MESSAGE(output.status==output_osqp.status,
                           "Status "+SolverHQPBase::HQP_status_string[output.status]+
                           " Status Proxqp "+SolverHQPBase::HQP_status_string[output_osqp.status]);
@@ -398,11 +398,11 @@ BOOST_AUTO_TEST_CASE ( test_eiquadprog_classic_vs_rt_vs_fast_vs_proxqp)
   //                        "\nSol FAST "+toString(output_fast.x.transpose())+
                           "\nDiff FAST: "+toString((output_rt.x-output_fast.x).norm()));
 
-    #ifdef TSID_PROXSUITE_FOUND
+    #ifdef TSID_WITH_PROXSUITE
       BOOST_CHECK_MESSAGE(output.x.isApprox(output_proxqp.x, 1e-4),
                 "\nDiff PROXQP: "+toString((output.x-output_proxqp.x).norm()));
     #endif
-    #ifdef TSID_OSQP_FOUND
+    #ifdef TSID_WITH_OSQP
       BOOST_CHECK_MESSAGE(output.x.isApprox(output_osqp.x, 1e-4),
                 "\nDiff OSQP: "+toString((output.x-output_osqp.x).norm()));
     #endif
@@ -422,11 +422,11 @@ BOOST_AUTO_TEST_CASE ( test_eiquadprog_classic_vs_rt_vs_fast_vs_proxqp)
   delete solver_rt;
   delete solver_fast;
 
-#ifdef TSID_PROXSUITE_FOUND
+#ifdef TSID_WITH_PROXSUITE
   delete solver_proxqp;
 #endif
 
-#ifdef TSID_OSQP_FOUND
+#ifdef TSID_WITH_OSQP
   delete solver_osqp;
 #endif
 }

--- a/tests/hqp_solvers.cpp
+++ b/tests/hqp_solvers.cpp
@@ -24,6 +24,12 @@
 #include <tsid/solvers/solver-HQP-eiquadprog.hpp>
 #include <tsid/solvers/solver-HQP-eiquadprog-rt.hpp>
 
+#ifdef TSID_PROXSUITE_FOUND
+  #include <tsid/solvers/solver-proxqp.hpp>
+#endif
+#ifdef TSID_OSQP_FOUND
+  #include <tsid/solvers/solver-osqp.hpp>
+#endif
 #ifdef TSID_QPMAD_FOUND
   #include <tsid/solvers/solver-HQP-qpmad.hpp>
 #endif
@@ -169,9 +175,11 @@ BOOST_AUTO_TEST_SUITE ( BOOST_TEST_MODULE )
 #define PROFILE_EIQUADPROG "Eiquadprog"
 #define PROFILE_EIQUADPROG_RT "Eiquadprog Real Time"
 #define PROFILE_EIQUADPROG_FAST "Eiquadprog Fast"
+#define PROFILE_PROXQP "Proxqp"
+#define PROFILE_OSQP "OSQP"
 #define PROFILE_QPMAD "QPMAD"
 
-BOOST_AUTO_TEST_CASE ( test_eiquadprog_classic_vs_rt_vs_fast)
+BOOST_AUTO_TEST_CASE ( test_eiquadprog_classic_vs_rt_vs_fast_vs_proxqp)
 {
   std::cout << "test_eiquadprog_classic_vs_rt_vs_fast\n";
   using namespace tsid;
@@ -180,9 +188,11 @@ BOOST_AUTO_TEST_CASE ( test_eiquadprog_classic_vs_rt_vs_fast)
 
   const double EPS = 1e-8;
 #ifdef NDEBUG
-  const unsigned int nTest = 1000;
+  const unsigned int nTest = 100;
+  const unsigned int nsmooth = 50;
 #else
   const unsigned int nTest = 100;
+  const unsigned int nsmooth = 5;
 #endif
   const unsigned int n = 60;
   const unsigned int neq = 36;
@@ -198,7 +208,7 @@ BOOST_AUTO_TEST_CASE ( test_eiquadprog_classic_vs_rt_vs_fast)
   // min margin of activation of the inequality constraints for the first QP
   const double MARGIN_PERC = 1e-3;
 
-  std::cout<<"Gonna perform "<<nTest<<" tests with "<<n<<" variables, "<<
+  std::cout<<"Gonna perform "<<nTest<<" tests (smooth " << nsmooth << " times) with "<<n<<" variables, "<<
 	  neq<<" equalities, "<<nin<<" inequalities\n";
 
   // CREATE SOLVERS
@@ -213,6 +223,16 @@ BOOST_AUTO_TEST_CASE ( test_eiquadprog_classic_vs_rt_vs_fast)
   SolverHQPBase * solver = SolverHQPFactory::createNewSolver(SOLVER_HQP_EIQUADPROG,
                                                              "eiquadprog");
   solver->resize(n, neq, nin);
+
+#ifdef TSID_PROXSUITE_FOUND
+  SolverHQPBase * solver_proxqp = SolverHQPFactory::createNewSolver(SOLVER_HQP_PROXQP,
+                                                             "proxqp");
+#endif
+
+#ifdef TSID_OSQP_FOUND
+  SolverHQPBase * solver_osqp = SolverHQPFactory::createNewSolver(SOLVER_HQP_OSQP,
+                                                             "osqp");
+#endif
 
 #ifdef TSID_QPMAD_FOUND
   SolverHQPBase * solver_qpmad = SolverHQPFactory::createNewSolver(SOLVER_HQP_QPMAD,
@@ -273,7 +293,7 @@ BOOST_AUTO_TEST_CASE ( test_eiquadprog_classic_vs_rt_vs_fast)
       cost->matrix() += hessianPerturbations[i];
       cost->vector() += gradientPerturbations[i];
     }
-
+  // First run to init outputs
     getProfiler().start(PROFILE_EIQUADPROG_FAST);
     const HQPOutput & output_fast = solver_fast->solve(HQPData);
     getProfiler().stop(PROFILE_EIQUADPROG_FAST);
@@ -286,11 +306,56 @@ BOOST_AUTO_TEST_CASE ( test_eiquadprog_classic_vs_rt_vs_fast)
     const HQPOutput & output    = solver->solve(HQPData);
     getProfiler().stop(PROFILE_EIQUADPROG);
 
+  #ifdef TSID_PROXSUITE_FOUND
+    getProfiler().start(PROFILE_PROXQP);
+    const HQPOutput & output_proxqp = solver_proxqp->solve(HQPData);
+    getProfiler().stop(PROFILE_PROXQP);
+  #endif
+
+  #ifdef TSID_OSQP_FOUND
+    getProfiler().start(PROFILE_OSQP);
+    const HQPOutput & output_osqp = solver_osqp->solve(HQPData);
+    getProfiler().stop(PROFILE_OSQP);
+  #endif
+
   #ifdef TSID_QPMAD_FOUND
     getProfiler().start(PROFILE_QPMAD);
     const HQPOutput & output_qpmad = solver_qpmad->solve(HQPData);
     getProfiler().stop(PROFILE_QPMAD);
   #endif
+    // Loop to smooth variance for each problem
+    for(unsigned int j=0; j<nsmooth; j++)
+    {
+      getProfiler().start(PROFILE_EIQUADPROG_FAST);
+      const HQPOutput & output_fast = solver_fast->solve(HQPData);
+      getProfiler().stop(PROFILE_EIQUADPROG_FAST);
+
+      getProfiler().start(PROFILE_EIQUADPROG_RT);
+      const HQPOutput & output_rt = solver_rt->solve(HQPData);
+      getProfiler().stop(PROFILE_EIQUADPROG_RT);
+
+      getProfiler().start(PROFILE_EIQUADPROG);
+      const HQPOutput & output    = solver->solve(HQPData);
+      getProfiler().stop(PROFILE_EIQUADPROG);
+
+    #ifdef TSID_PROXSUITE_FOUND
+      getProfiler().start(PROFILE_PROXQP);
+      const HQPOutput & output_proxqp = solver_proxqp->solve(HQPData);
+      getProfiler().stop(PROFILE_PROXQP);
+    #endif
+
+    #ifdef TSID_OSQP_FOUND
+      getProfiler().start(PROFILE_OSQP);
+      const HQPOutput & output_osqp = solver_osqp->solve(HQPData);
+      getProfiler().stop(PROFILE_OSQP);
+    #endif
+
+    #ifdef TSID_QPMAD_FOUND
+      getProfiler().start(PROFILE_QPMAD);
+      const HQPOutput & output_qpmad = solver_qpmad->solve(HQPData);
+      getProfiler().stop(PROFILE_QPMAD);
+    #endif
+    }
 
     getStatistics().store("active inequalities", (double)output_rt.activeSet.size());
     getStatistics().store("solver iterations", output_rt.iterations);
@@ -301,6 +366,17 @@ BOOST_AUTO_TEST_CASE ( test_eiquadprog_classic_vs_rt_vs_fast)
     BOOST_REQUIRE_MESSAGE(output.status==output_fast.status,
                           "Status "+SolverHQPBase::HQP_status_string[output.status]+
                           " Status FAST "+SolverHQPBase::HQP_status_string[output_fast.status]);
+
+  #ifdef TSID_PROXSUITE_FOUND
+    BOOST_REQUIRE_MESSAGE(output.status==output_proxqp.status,
+                          "Status "+SolverHQPBase::HQP_status_string[output.status]+
+                          " Status Proxqp "+SolverHQPBase::HQP_status_string[output_proxqp.status]);
+  #endif
+  #ifdef TSID_OSQP_FOUND
+    BOOST_REQUIRE_MESSAGE(output.status==output_osqp.status,
+                          "Status "+SolverHQPBase::HQP_status_string[output.status]+
+                          " Status Proxqp "+SolverHQPBase::HQP_status_string[output_osqp.status]);
+  #endif
 
     if(output.status==HQP_STATUS_OPTIMAL)
     {
@@ -322,6 +398,15 @@ BOOST_AUTO_TEST_CASE ( test_eiquadprog_classic_vs_rt_vs_fast)
   //                        "\nSol FAST "+toString(output_fast.x.transpose())+
                           "\nDiff FAST: "+toString((output_rt.x-output_fast.x).norm()));
 
+    #ifdef TSID_PROXSUITE_FOUND
+      BOOST_CHECK_MESSAGE(output.x.isApprox(output_proxqp.x, 1e-4),
+                "\nDiff PROXQP: "+toString((output.x-output_proxqp.x).norm()));
+    #endif
+    #ifdef TSID_OSQP_FOUND
+      BOOST_CHECK_MESSAGE(output.x.isApprox(output_osqp.x, 1e-4),
+                "\nDiff OSQP: "+toString((output.x-output_osqp.x).norm()));
+    #endif
+
     #ifdef TSID_QPMAD_FOUND
       BOOST_CHECK_MESSAGE(output.x.isApprox(output_qpmad.x, EPS),
                           "\nDiff QPMAD: "+toString((output.x-output_qpmad.x).norm()));
@@ -336,6 +421,14 @@ BOOST_AUTO_TEST_CASE ( test_eiquadprog_classic_vs_rt_vs_fast)
   delete solver;
   delete solver_rt;
   delete solver_fast;
+
+#ifdef TSID_PROXSUITE_FOUND
+  delete solver_proxqp;
+#endif
+
+#ifdef TSID_OSQP_FOUND
+  delete solver_osqp;
+#endif
 }
 
 

--- a/tests/python/CMakeLists.txt
+++ b/tests/python/CMakeLists.txt
@@ -2,9 +2,13 @@ set(${PYWRAP}_TESTS
     # Constraint
     # ContactPoint
     # Contact
-    Formulation Gravity RobotWrapper
+    Formulation
+    Gravity
+    RobotWrapper
     Solvers
-    Tasks Trajectories Deprecations)
+    Tasks
+    Trajectories
+    Deprecations)
 
 foreach(test ${${PYWRAP}_TESTS})
   add_python_unit_test("py-${test}" "tests/python/test_${test}.py"

--- a/tests/python/CMakeLists.txt
+++ b/tests/python/CMakeLists.txt
@@ -3,7 +3,7 @@ set(${PYWRAP}_TESTS
     # ContactPoint
     # Contact
     Formulation Gravity RobotWrapper
-    # Solvers
+    Solvers
     Tasks Trajectories Deprecations)
 
 foreach(test ${${PYWRAP}_TESTS})


### PR DESCRIPTION
Hello, with this PR I would like to propose a way to integrate **PROXQP** and **OSQP** solver into TSID. I added options to the CMakeLists file to support the solvers, which will first check if the [proxsuite](https://github.com/simple-robotics/proxsuite) and [osqp-eigen](https://github.com/robotology/osqp-eigen) are available (both can be easily installed via conda for example).

The integration is done in c++ and I added the corresponding python bindings. The unittests, both cpp and python, got modified to test also the new solvers.

In addition to the `HQPData` (holding the constraints and cost as TSID objects), this PR adds a struct called QPData which is gathering all necessary eigen matrices to describe a QP problem. Currently, these matrices are members of each solver.

I am looking forward to your feedback.