### PR TITLE
Expose AddMotionTask for TaskJointPosVelAccBounds

### DIFF
--- a/include/tsid/bindings/python/formulations/formulation.hpp
+++ b/include/tsid/bindings/python/formulations/formulation.hpp
@@ -32,6 +32,7 @@
 #include "tsid/tasks/task-cop-equality.hpp"
 #include "tsid/tasks/task-actuation-bounds.hpp"
 #include "tsid/tasks/task-joint-bounds.hpp"
+#include "tsid/tasks/task-joint-posVelAcc-bounds.hpp"
 #include "tsid/tasks/task-angular-momentum-equality.hpp"
 
 
@@ -60,6 +61,7 @@ namespace tsid
         .def("addMotionTask", &InvDynPythonVisitor::addMotionTask_COM, bp::args("task", "weight", "priorityLevel", "transition duration"))
         .def("addMotionTask", &InvDynPythonVisitor::addMotionTask_Joint, bp::args("task", "weight", "priorityLevel", "transition duration"))
         .def("addMotionTask", &InvDynPythonVisitor::addMotionTask_JointBounds, bp::args("task", "weight", "priorityLevel", "transition duration"))
+        .def("addMotionTask", &InvDynPythonVisitor::addMotionTask_JointPosVelAccBounds, bp::args("task", "weight", "priorityLevel", "transition duration"))
         .def("addMotionTask", &InvDynPythonVisitor::addMotionTask_AM, bp::args("task", "weight", "priorityLevel", "transition duration"))
         .def("addForceTask", &InvDynPythonVisitor::addForceTask_COP, bp::args("task", "weight", "priorityLevel", "transition duration"))
         .def("addActuationTask", &InvDynPythonVisitor::addActuationTask_Bounds, bp::args("task", "weight", "priorityLevel", "transition duration"))
@@ -98,6 +100,9 @@ namespace tsid
         return self.addMotionTask(task, weight, priorityLevel, transition_duration);
       }
       static bool addMotionTask_JointBounds(T & self, tasks::TaskJointBounds & task, double weight, unsigned int priorityLevel, double transition_duration){
+        return self.addMotionTask(task, weight, priorityLevel, transition_duration);
+      }
+      static bool addMotionTask_JointPosVelAccBounds(T & self, tasks::TaskJointPosVelAccBounds & task, double weight, unsigned int priorityLevel, double transition_duration){
         return self.addMotionTask(task, weight, priorityLevel, transition_duration);
       }
       static bool addMotionTask_AM(T & self, tasks::TaskAMEquality & task, double weight, unsigned int priorityLevel, double transition_duration){


### PR DESCRIPTION
Hello,

While stashing some debugging code for #189 (#187), I stashed one too many files. Thus, the binding for adding the newly exposed task to the formulation was not included in the PR.

Here is the binding.

My apologies.  