### PR TITLE
Input argument checking + fix virtual destructor issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ set(PROJECT_DESCRIPTION
 set(PROJECT_URL "https://github.com/${PROJECT_ORG}/${PROJECT_NAME}")
 
 # Project options
+option(INSTALL_DOCUMENTATION "Build and install the documentation" OFF)
 option(BUILD_PYTHON_INTERFACE "Build the python bindings" ON)
 option(INSTALL_PYTHON_INTERFACE_ONLY "Install *ONLY* the python bindings" OFF)
 option(SUFFIX_SO_VERSION "Suffix library name with its version" ON)

--- a/include/tsid/contacts/contact-6d.hpp
+++ b/include/tsid/contacts/contact-6d.hpp
@@ -63,6 +63,8 @@ namespace tsid
                 const double maxNormalForce,
                 const double forceRegWeight);
 
+      virtual ~Contact6d() {}
+
       /// Return the number of motion constraints
       virtual unsigned int n_motion() const;
 

--- a/include/tsid/contacts/contact-base.hpp
+++ b/include/tsid/contacts/contact-base.hpp
@@ -49,6 +49,8 @@ namespace tsid
       ContactBase(const std::string & name,
                   RobotWrapper & robot);
 
+      virtual ~ContactBase() {}
+
       const std::string & name() const;
 
       void name(const std::string & name);

--- a/include/tsid/contacts/contact-point.hpp
+++ b/include/tsid/contacts/contact-point.hpp
@@ -51,6 +51,8 @@ namespace tsid
                 const double minNormalForce,
                 const double maxNormalForce);
 
+      virtual ~ContactPoint() {}
+
       /// Return the number of motion constraints
       virtual unsigned int n_motion() const;
 

--- a/include/tsid/formulations/inverse-dynamics-formulation-acc-force.hpp
+++ b/include/tsid/formulations/inverse-dynamics-formulation-acc-force.hpp
@@ -60,6 +60,8 @@ namespace tsid
                                        RobotWrapper & robot,
                                        bool verbose=false);
 
+    virtual ~InverseDynamicsFormulationAccForce() {}
+
     Data & data() ;
 
     unsigned int nVar() const;

--- a/include/tsid/formulations/inverse-dynamics-formulation-base.hpp
+++ b/include/tsid/formulations/inverse-dynamics-formulation-base.hpp
@@ -82,6 +82,8 @@ namespace tsid
                                    RobotWrapper & robot,
                                    bool verbose=false);
 
+    virtual ~InverseDynamicsFormulationBase() {}
+
     virtual Data & data() = 0;
 
     virtual unsigned int nVar() const = 0;

--- a/include/tsid/math/constraint-base.hpp
+++ b/include/tsid/math/constraint-base.hpp
@@ -20,6 +20,7 @@
 
 #include "tsid/math/fwd.hpp"
 #include <string>
+#include <pinocchio/macros.hpp>
 
 namespace tsid
 {

--- a/include/tsid/robots/robot-wrapper.hpp
+++ b/include/tsid/robots/robot-wrapper.hpp
@@ -78,6 +78,8 @@ namespace tsid
       RobotWrapper(const Model & m,
                    RootJointType rootJoint,
                    bool verbose=false);
+
+      virtual ~RobotWrapper() {}
       
       virtual int nq() const;
       virtual int nq_actuated() const;

--- a/include/tsid/solvers/solver-HQP-eiquadprog-rt.hxx
+++ b/include/tsid/solvers/solver-HQP-eiquadprog-rt.hxx
@@ -75,7 +75,7 @@ namespace tsid
       
       if(problemData.size()>2)
       {
-        assert(false && "Solver not implemented for more than 2 hierarchical levels.");
+        PINOCCHIO_CHECK_INPUT_ARGUMENT(false, "Solver not implemented for more than 2 hierarchical levels.");
       }
       
       // Compute the constraint matrix sizes
@@ -139,7 +139,7 @@ namespace tsid
           const double & w = it->first;
           auto constr = it->second;
           if(!constr->isEquality())
-            assert(false && "Inequalities in the cost function are not implemented yet");
+            PINOCCHIO_CHECK_INPUT_ARGUMENT(false, "Inequalities in the cost function are not implemented yet");
           
           EIGEN_MALLOC_ALLOWED
           m_H.noalias() += w*constr->matrix().transpose()*constr->matrix();

--- a/include/tsid/solvers/solver-HQP-factory.hpp
+++ b/include/tsid/solvers/solver-HQP-factory.hpp
@@ -21,6 +21,8 @@
 #include <tsid/solvers/solver-HQP-base.hpp>
 #include <tsid/solvers/solver-HQP-eiquadprog-rt.hpp>
 
+#include <pinocchio/macros.hpp>  // for input argument checking and exceptions
+
 
 namespace tsid
 {

--- a/include/tsid/solvers/solver-HQP-factory.hxx
+++ b/include/tsid/solvers/solver-HQP-factory.hxx
@@ -34,8 +34,8 @@ namespace tsid
       if(solverType==SOLVER_HQP_EIQUADPROG_RT)
         return new SolverHQuadProgRT<nVars, nEqCon, nIneqCon>(name);
       
-      assert(false && "Specified solver type not recognized");
-      return NULL;
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(false, "Specified solver type not recognized");
+      return nullptr;
     }
   }
 }

--- a/include/tsid/tasks/task-actuation-bounds.hpp
+++ b/include/tsid/tasks/task-actuation-bounds.hpp
@@ -42,6 +42,8 @@ namespace tsid
       TaskActuationBounds(const std::string & name,
                           RobotWrapper & robot);
 
+      virtual ~TaskActuationBounds() {}
+
       int dim() const;
 
       const ConstraintBase & compute(const double t,

--- a/include/tsid/tasks/task-actuation-equality.hpp
+++ b/include/tsid/tasks/task-actuation-equality.hpp
@@ -39,6 +39,8 @@ namespace tsid
       TaskActuationEquality(const std::string & name,
                             RobotWrapper & robot);
 
+      virtual ~TaskActuationEquality() {}
+
       int dim() const;
 
       const ConstraintBase & compute(const double t,

--- a/include/tsid/tasks/task-actuation.hpp
+++ b/include/tsid/tasks/task-actuation.hpp
@@ -30,6 +30,8 @@ namespace tsid
 
       TaskActuation(const std::string & name,
                     RobotWrapper & robot);
+
+      virtual ~TaskActuation() {}
     };
   }
 }

--- a/include/tsid/tasks/task-angular-momentum-equality.hpp
+++ b/include/tsid/tasks/task-angular-momentum-equality.hpp
@@ -47,6 +47,8 @@ namespace tsid
       TaskAMEquality(const std::string & name, 
                       RobotWrapper & robot);
 
+      virtual ~TaskAMEquality() {}
+
       int dim() const;
 
       const ConstraintBase & compute(const double t,

--- a/include/tsid/tasks/task-base.hpp
+++ b/include/tsid/tasks/task-base.hpp
@@ -46,6 +46,8 @@ namespace tsid
       TaskBase(const std::string & name,
                RobotWrapper & robot);
 
+      virtual ~TaskBase() {}
+
       const std::string & name() const;
 
       void name(const std::string & name);

--- a/include/tsid/tasks/task-capture-point-inequality.hpp
+++ b/include/tsid/tasks/task-capture-point-inequality.hpp
@@ -47,6 +47,8 @@ namespace tsid
                                RobotWrapper & robot,
                                const double timeStep);
 
+      virtual ~TaskCapturePointInequality() {}
+
       int dim() const;
 
       const ConstraintBase & compute(const double t,

--- a/include/tsid/tasks/task-com-equality.hpp
+++ b/include/tsid/tasks/task-com-equality.hpp
@@ -42,6 +42,8 @@ namespace tsid
       TaskComEquality(const std::string & name,
                       RobotWrapper & robot);
 
+      virtual ~TaskComEquality() {}
+
       int dim() const;
 
       const ConstraintBase & compute(const double t,

--- a/include/tsid/tasks/task-contact-force-equality.hpp
+++ b/include/tsid/tasks/task-contact-force-equality.hpp
@@ -47,6 +47,8 @@ namespace tsid
                                const double dt,
                       		     contacts::ContactBase & contact);
 
+      virtual ~TaskContactForceEquality() {}
+
       int dim() const;
 
       virtual const std::string& getAssociatedContactName();

--- a/include/tsid/tasks/task-contact-force.hpp
+++ b/include/tsid/tasks/task-contact-force.hpp
@@ -35,6 +35,8 @@ namespace tsid
       TaskContactForce(const std::string & name,
                        RobotWrapper & robot);
 
+      virtual ~TaskContactForce() {}
+
       /**
        * Contact force tasks have an additional compute method that takes as extra input
        * argument the list of active contacts. This can be needed for force tasks that

--- a/include/tsid/tasks/task-cop-equality.hpp
+++ b/include/tsid/tasks/task-cop-equality.hpp
@@ -44,6 +44,8 @@ namespace tsid
       TaskCopEquality(const std::string & name,
                       RobotWrapper & robot);
 
+      virtual ~TaskCopEquality() {}
+
       void setContactList(const std::vector<std::shared_ptr<ContactLevel> >  *contacts);
 
       int dim() const;

--- a/include/tsid/tasks/task-joint-bounds.hpp
+++ b/include/tsid/tasks/task-joint-bounds.hpp
@@ -39,6 +39,8 @@ namespace tsid
                       RobotWrapper & robot,
                       double dt);
 
+      virtual ~TaskJointBounds() {}
+
       int dim() const;
 
       const ConstraintBase & compute(const double t,

--- a/include/tsid/tasks/task-joint-posVelAcc-bounds.hpp
+++ b/include/tsid/tasks/task-joint-posVelAcc-bounds.hpp
@@ -51,6 +51,8 @@ namespace tsid
                       double dt,
                       bool verbose=true);
 
+      virtual ~TaskJointPosVelAccBounds() {}
+
       int dim() const;
 
       const ConstraintBase & compute(const double t,

--- a/include/tsid/tasks/task-joint-posture.hpp
+++ b/include/tsid/tasks/task-joint-posture.hpp
@@ -43,6 +43,8 @@ namespace tsid
       TaskJointPosture(const std::string & name,
                       RobotWrapper & robot);
 
+      virtual ~TaskJointPosture() {}
+
       int dim() const;
 
       const ConstraintBase & compute(const double t,

--- a/include/tsid/tasks/task-motion.hpp
+++ b/include/tsid/tasks/task-motion.hpp
@@ -36,6 +36,8 @@ namespace tsid
       TaskMotion(const std::string & name,
                  RobotWrapper & robot);
 
+      virtual ~TaskMotion() {}
+
       virtual const TrajectorySample & getReference() const;
 
       virtual const Vector & getDesiredAcceleration() const;

--- a/include/tsid/tasks/task-se3-equality.hpp
+++ b/include/tsid/tasks/task-se3-equality.hpp
@@ -48,6 +48,8 @@ namespace tsid
                       RobotWrapper & robot,
                       const std::string & frameName);
 
+      virtual ~TaskSE3Equality() {}
+
       int dim() const;
 
       const ConstraintBase & compute(const double t,

--- a/include/tsid/trajectories/trajectory-base.hpp
+++ b/include/tsid/trajectories/trajectory-base.hpp
@@ -89,6 +89,8 @@ TSID_DISABLE_WARNING_POP
       TrajectoryBase(const std::string & name):
         m_name(name){}
 
+      virtual ~TrajectoryBase() {}
+
       virtual unsigned int size() const = 0;
 
       virtual const TrajectorySample & operator()(double time) = 0;

--- a/include/tsid/trajectories/trajectory-euclidian.hpp
+++ b/include/tsid/trajectories/trajectory-euclidian.hpp
@@ -37,6 +37,8 @@ namespace tsid
 
       TrajectoryEuclidianConstant(const std::string & name, ConstRefVector ref);
 
+      virtual ~TrajectoryEuclidianConstant() {}
+
       unsigned int size() const;
 
       void setReference(ConstRefVector ref);

--- a/include/tsid/trajectories/trajectory-se3.hpp
+++ b/include/tsid/trajectories/trajectory-se3.hpp
@@ -38,6 +38,8 @@ namespace tsid
 
       TrajectorySE3Constant(const std::string & name, const SE3 & M);
 
+      virtual ~TrajectorySE3Constant() {}
+
       unsigned int size() const;
 
       void setReference(const SE3 & M);

--- a/src/contacts/contact-6d.cpp
+++ b/src/contacts/contact-6d.cpp
@@ -119,7 +119,7 @@ void Contact6d::updateForceInequalityConstraints()
 
 double Contact6d::getNormalForce(ConstRefVector f) const
 {
-  assert(f.size()==n_force());
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(f.size() == n_force(), "f needs to contain " + std::to_string(n_force()) + " rows");
   double n=0.0;
   for(int i=0; i<4; i++)
     n += m_contactNormal.dot(f.segment<3>(i*3));
@@ -162,8 +162,8 @@ void Contact6d::Kd(ConstRefVector Kd){ m_motionTask.Kd(Kd); }
 
 bool Contact6d::setContactPoints(ConstRefMatrix contactPoints)
 {
-  assert(contactPoints.rows()==3);
-  assert(contactPoints.cols()==4);
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(contactPoints.rows() == 3, "The number of rows needs to be 3");
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(contactPoints.cols() == 4, "The number of cols needs to be 4");
   if(contactPoints.rows()!=3 || contactPoints.cols()!=4)
     return false;
   m_contactPoints = contactPoints;
@@ -178,7 +178,7 @@ const Matrix3x & Contact6d::getContactPoints() const
 
 bool Contact6d::setContactNormal(ConstRefVector contactNormal)
 {
-  assert(contactNormal.size()==3);
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(contactNormal.size() == 3, "The size of the contactNormal vector needs to equal 3");
   if(contactNormal.size()!=3)
     return false;
   m_contactNormal = contactNormal;
@@ -188,7 +188,7 @@ bool Contact6d::setContactNormal(ConstRefVector contactNormal)
 
 bool Contact6d::setFrictionCoefficient(const double frictionCoefficient)
 {
-  assert(frictionCoefficient>0.0);
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(frictionCoefficient > 0.0, "The friction coefficient needs to be positive");
   if(frictionCoefficient<=0.0)
     return false;
   m_mu = frictionCoefficient;
@@ -198,7 +198,7 @@ bool Contact6d::setFrictionCoefficient(const double frictionCoefficient)
 
 bool Contact6d::setMinNormalForce(const double minNormalForce)
 {
-  assert(minNormalForce>0.0 && minNormalForce<=m_fMax);
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(minNormalForce > 0.0 && minNormalForce <= m_fMax, "The minimal normal force needs to be greater than 0 and less than or equal to the maximal force");
   if(minNormalForce<=0.0 || minNormalForce>m_fMax)
     return false;
   m_fMin = minNormalForce;
@@ -209,7 +209,7 @@ bool Contact6d::setMinNormalForce(const double minNormalForce)
 
 bool Contact6d::setMaxNormalForce(const double maxNormalForce)
 {
-  assert(maxNormalForce>=m_fMin);
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(maxNormalForce >= m_fMin, "The maximal force needs to be greater than or equal to the minimal force");
   if(maxNormalForce<m_fMin)
     return false;
   m_fMax = maxNormalForce;

--- a/src/contacts/contact-point.cpp
+++ b/src/contacts/contact-point.cpp
@@ -92,7 +92,7 @@ void ContactPoint::updateForceInequalityConstraints()
 
 double ContactPoint::getNormalForce(ConstRefVector f) const
 {
-  assert(f.size()==n_force());
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(f.size() == n_force(), "Size of f is wrong - needs to be " + std::to_string(n_force()));
   return m_contactNormal.dot(f);
 }
 
@@ -138,7 +138,7 @@ const Vector & ContactPoint::Kd()
 
 void ContactPoint::Kp(ConstRefVector Kp)
 {
-  assert(Kp.size()==3);
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(Kp.size() == 3, "Size of Kp vector needs to equal 3");
   Vector6 Kp6;
   Kp6.head<3>() = Kp;
   m_motionTask.Kp(Kp6);
@@ -146,7 +146,7 @@ void ContactPoint::Kp(ConstRefVector Kp)
 
 void ContactPoint::Kd(ConstRefVector Kd)
 {
-  assert(Kd.size()==3);
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(Kd.size() == 3, "Size of Kd vector needs to equal 3");
   Vector6 Kd6;
   Kd6.head<3>() = Kd;
   m_motionTask.Kd(Kd6);
@@ -154,7 +154,7 @@ void ContactPoint::Kd(ConstRefVector Kd)
 
 bool ContactPoint::setContactNormal(ConstRefVector contactNormal)
 {
-  assert(contactNormal.size()==3);
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(contactNormal.size() == 3, "Size of contact normal vector needs to equal 3");
   if(contactNormal.size()!=3)
     return false;
   m_contactNormal = contactNormal;
@@ -164,7 +164,7 @@ bool ContactPoint::setContactNormal(ConstRefVector contactNormal)
 
 bool ContactPoint::setFrictionCoefficient(const double frictionCoefficient)
 {
-  assert(frictionCoefficient>0.0);
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(frictionCoefficient > 0.0, "Friction coefficient needs to be positive");
   if(frictionCoefficient<=0.0)
     return false;
   m_mu = frictionCoefficient;
@@ -174,7 +174,7 @@ bool ContactPoint::setFrictionCoefficient(const double frictionCoefficient)
 
 bool ContactPoint::setMinNormalForce(const double minNormalForce)
 {
-  assert(minNormalForce>0.0 && minNormalForce<=m_fMax);
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(minNormalForce > 0.0 && minNormalForce <= m_fMax, "The minimal normal force needs to be greater than 0 and less than or equal to the maximum force.");
   if(minNormalForce<=0.0 || minNormalForce>m_fMax)
     return false;
   m_fMin = minNormalForce;
@@ -185,7 +185,7 @@ bool ContactPoint::setMinNormalForce(const double minNormalForce)
 
 bool ContactPoint::setMaxNormalForce(const double maxNormalForce)
 {
-  assert(maxNormalForce>=m_fMin);
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(maxNormalForce >= m_fMin, "The maximal normal force needs to be greater than or equal to the minimal force");
   if(maxNormalForce<m_fMin)
     return false;
   m_fMax = maxNormalForce;

--- a/src/formulations/inverse-dynamics-formulation-acc-force.cpp
+++ b/src/formulations/inverse-dynamics-formulation-acc-force.cpp
@@ -114,17 +114,8 @@ bool InverseDynamicsFormulationAccForce::addMotionTask(TaskMotion & task,
                                                        unsigned int priorityLevel,
                                                        double transition_duration)
 {
-  assert(weight>=0.0);
-  assert(transition_duration>=0.0);
-  
-  // This part is not used frequently so we can do some tests.
-  if (weight<0.0)
-    std::cerr << __FILE__ <<  " " << __LINE__ << " "
-      << "weight should be positive" << std::endl;
-
-  // This part is not used frequently so we can do some tests.
-  if (transition_duration<0.0)
-    std::cerr << "transition_duration should be positive" << std::endl;
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(weight >= 0.0, "The weight needs to be positive or equal to 0");
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(transition_duration >= 0.0, "The transition duration needs to be greater than or equal to 0");
 
   auto tl = std::make_shared<TaskLevel>(task, priorityLevel);
   m_taskMotions.push_back(tl);
@@ -139,16 +130,9 @@ bool InverseDynamicsFormulationAccForce::addForceTask(TaskContactForce & task,
                                                       unsigned int priorityLevel,
                                                       double transition_duration)
 {
-  assert(weight>=0.0);
-  assert(transition_duration>=0.0);
-  // This part is not used frequently so we can do some tests.
-  if (weight<0.0)
-    std::cerr << __FILE__ <<  " " << __LINE__ << " "
-      << "weight should be positive" << std::endl;
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(weight >= 0.0, "The weight needs to be positive or equal to 0");
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(transition_duration >= 0.0, "The transition duration needs to be greater than or equal to 0");
 
-  // This part is not used frequently so we can do some tests.
-  if (transition_duration<0.0)
-    std::cerr << "transition_duration should be positive" << std::endl;
   auto tl = std::make_shared<TaskLevelForce>(task, priorityLevel);
   m_taskContactForces.push_back(tl);
   addTask(tl, weight, priorityLevel);
@@ -161,15 +145,8 @@ bool InverseDynamicsFormulationAccForce::addActuationTask(TaskActuation & task,
                                                           unsigned int priorityLevel,
                                                           double transition_duration)
 {
-  assert(weight>=0.0);
-  assert(transition_duration>=0.0);
-  if (weight<0.0)
-    std::cerr << __FILE__ <<  " " << __LINE__ << " "
-	      << "weight should be positive" << std::endl;
-
-  // This part is not used frequently so we can do some tests.
-  if (transition_duration<0.0)
-    std::cerr << "transition_duration should be positive" << std::endl;
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(weight >= 0.0, "The weight needs to be positive or equal to 0");
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(transition_duration >= 0.0, "The transition duration needs to be greater than or equal to 0");
 
   auto tl = std::make_shared<TaskLevel>(task, priorityLevel);
   m_taskActuations.push_back(tl);

--- a/src/math/constraint-base.cpp
+++ b/src/math/constraint-base.cpp
@@ -53,8 +53,8 @@ Matrix & ConstraintBase::matrix()
 
 bool ConstraintBase::setMatrix(ConstRefMatrix A)
 {
-  assert(m_A.cols()==A.cols());
-  assert(m_A.rows()==A.rows());
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(m_A.cols() == A.cols(), "cols do not match the constraint dimension");
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(m_A.rows() == A.rows(), "rows do not match the constraint dimension");
   m_A = A;
   return true;
 }

--- a/src/math/constraint-bound.cpp
+++ b/src/math/constraint-bound.cpp
@@ -38,7 +38,7 @@ ConstraintBound::ConstraintBound(const std::string & name,
   m_lb(lb),
   m_ub(ub)
 {
-  assert(lb.size()==ub.size());
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(lb.size() == ub.size(), "The size of the lower and upper bound vectors needs to be match!");
 }
 
 unsigned int ConstraintBound::rows() const
@@ -55,7 +55,7 @@ unsigned int ConstraintBound::cols() const
 
 void ConstraintBound::resize(const unsigned int r, const unsigned int c)
 {
-  assert(r==c);
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(r == c, "r and c need to be equal!");
   m_A.setIdentity(r, c);
   m_lb.setZero(r);
   m_ub.setZero(r);

--- a/src/math/constraint-equality.cpp
+++ b/src/math/constraint-equality.cpp
@@ -36,7 +36,7 @@ ConstraintEquality::ConstraintEquality(const std::string & name,
   ConstraintBase(name, A),
   m_b(b)
 {
-  assert(A.rows()==b.rows());
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(A.rows()==b.rows(), "The number of rows for A and b do not match");
 }
 
 unsigned int ConstraintEquality::rows() const

--- a/src/math/constraint-inequality.cpp
+++ b/src/math/constraint-inequality.cpp
@@ -39,8 +39,8 @@ ConstraintInequality::ConstraintInequality(const std::string & name,
   m_lb(lb),
   m_ub(ub)
 {
-  assert(A.rows()==lb.rows());
-  assert(A.rows()==ub.rows());
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(A.rows() == lb.rows(), "The number of rows of A and lb do not match");
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(A.rows() == ub.rows(), "The number of rows of A and ub do not match");
 }
 
 unsigned int ConstraintInequality::rows() const

--- a/src/math/utils.cpp
+++ b/src/math/utils.cpp
@@ -24,14 +24,14 @@ namespace tsid
     
     void SE3ToXYZQUAT(const pinocchio::SE3 & M, RefVector xyzQuat)
     {
-      assert(xyzQuat.size()==7);
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(xyzQuat.size() == 7, "The size of the xyzQuat vector needs to equal 7");
       xyzQuat.head<3>() = M.translation();
       xyzQuat.tail<4>() = Eigen::Quaterniond(M.rotation()).coeffs();
     }
 
     void SE3ToVector(const pinocchio::SE3 & M, RefVector vec)
     {
-      assert(vec.size()==12);
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(vec.size() == 12, "The size of the vec vector needs to equal 12");
       vec.head<3>() = M.translation();
       typedef Eigen::Matrix<double,9,1> Vector9;
       vec.tail<9>() = Eigen::Map<const Vector9>(&M.rotation()(0), 9);
@@ -39,7 +39,7 @@ namespace tsid
 
     void vectorToSE3(RefVector vec, pinocchio::SE3 & M)
     {
-      assert(vec.size()==12);
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(vec.size() == 12, "vec needs to contain 12 rows");
       M.translation( vec.head<3>() );
       typedef Eigen::Matrix<double,3,3> Matrix3;
       M.rotation( Eigen::Map<const Matrix3>(&vec(3), 3, 3) );

--- a/src/robots/robot-wrapper.cpp
+++ b/src/robots/robot-wrapper.cpp
@@ -136,7 +136,7 @@ namespace tsid
     
     bool RobotWrapper::rotor_inertias(ConstRefVector rotor_inertias)
     {
-      assert(rotor_inertias.size()==m_rotor_inertias.size());
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(rotor_inertias.size() == m_rotor_inertias.size(), "The size of the rotor_inertias vector is incorrect!");
       m_rotor_inertias = rotor_inertias;
       updateMd();
       return true;
@@ -144,7 +144,7 @@ namespace tsid
     
     bool RobotWrapper::gear_ratios(ConstRefVector gear_ratios)
     {
-      assert(gear_ratios.size()==m_gear_ratios.size());
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(gear_ratios.size() == m_gear_ratios.size(), "The size of the gear_ratios vector is incorrect!");
       m_gear_ratios = gear_ratios;
       updateMd();
       return true;
@@ -200,21 +200,21 @@ namespace tsid
     const SE3 & RobotWrapper::position(const Data & data,
                                        const Model::JointIndex index) const
     {
-      assert(index<data.oMi.size());
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(index < data.oMi.size(), "The index needs to be less than the size of the oMi vector");
       return data.oMi[index];
     }
     
     const Motion & RobotWrapper::velocity(const Data & data,
                                           const Model::JointIndex index) const
     {
-      assert(index<data.v.size());
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(index < data.v.size(), "The index needs to be less than the size of the v vector");
       return data.v[index];
     }
     
     const Motion & RobotWrapper::acceleration(const Data & data,
                                               const Model::JointIndex index) const
     {
-      assert(index<data.a.size());
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(index < data.a.size(), "The index needs to be less than the size of the a vector");
       return data.a[index];
     }
     
@@ -222,7 +222,7 @@ namespace tsid
                                      const Model::JointIndex index,
                                      Data::Matrix6x & J) const
     {
-      assert(index<data.oMi.size());
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(index < data.oMi.size(), "The index needs to be less than the size of the oMi vector");
       return pinocchio::getJointJacobian(m_model, data, index, pinocchio::WORLD, J);
     }
     
@@ -230,14 +230,14 @@ namespace tsid
                                      const Model::JointIndex index,
                                      Data::Matrix6x & J) const
     {
-      assert(index<data.oMi.size());
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(index < data.oMi.size(), "The index needs to be less than the size of the oMi vector");
       return pinocchio::getJointJacobian(m_model, data, index, pinocchio::LOCAL, J);
     }
     
     SE3 RobotWrapper::framePosition(const Data & data,
                                     const Model::FrameIndex index) const
     {
-      assert(index<m_model.frames.size());
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(index < m_model.frames.size(), "Frame index greater than size of frame vector in model - frame may not exist");
       const Frame & f = m_model.frames[index];
       return data.oMi[f.parent].act(f.placement);
     }
@@ -246,7 +246,7 @@ namespace tsid
                                      const Model::FrameIndex index,
                                      SE3 & framePosition) const
     {
-      assert(index<m_model.frames.size());
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(index < m_model.frames.size(), "Frame index greater than size of frame vector in model - frame may not exist");
       const Frame & f = m_model.frames[index];
       framePosition = data.oMi[f.parent].act(f.placement);
     }
@@ -254,7 +254,7 @@ namespace tsid
     Motion RobotWrapper::frameVelocity(const Data & data,
                                        const Model::FrameIndex index) const
     {
-      assert(index<m_model.frames.size());
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(index < m_model.frames.size(), "Frame index greater than size of frame vector in model - frame may not exist");
       const Frame & f = m_model.frames[index];
       return f.placement.actInv(data.v[f.parent]);
     }
@@ -263,7 +263,7 @@ namespace tsid
                                      const Model::FrameIndex index,
                                      Motion & frameVelocity) const
     {
-      assert(index<m_model.frames.size());
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(index < m_model.frames.size(), "Frame index greater than size of frame vector in model - frame may not exist");
       const Frame & f = m_model.frames[index];
       frameVelocity = f.placement.actInv(data.v[f.parent]);
     }
@@ -283,7 +283,7 @@ namespace tsid
     Motion RobotWrapper::frameAcceleration(const Data & data,
                                            const Model::FrameIndex index) const
     {
-      assert(index<m_model.frames.size());
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(index < m_model.frames.size(), "Frame index greater than size of frame vector in model - frame may not exist");
       const Frame & f = m_model.frames[index];
       return f.placement.actInv(data.a[f.parent]);
     }
@@ -292,7 +292,7 @@ namespace tsid
                                          const Model::FrameIndex index,
                                          Motion & frameAcceleration) const
     {
-      assert(index<m_model.frames.size());
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(index < m_model.frames.size(), "Frame index greater than size of frame vector in model - frame may not exist");
       const Frame & f = m_model.frames[index];
       frameAcceleration = f.placement.actInv(data.a[f.parent]);
     }
@@ -312,7 +312,7 @@ namespace tsid
     Motion RobotWrapper::frameClassicAcceleration(const Data & data,
                                                   const Model::FrameIndex index) const
     {
-      assert(index<m_model.frames.size());
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(index < m_model.frames.size(), "Frame index greater than size of frame vector in model - frame may not exist");
       const Frame & f = m_model.frames[index];
       Motion a = f.placement.actInv(data.a[f.parent]);
       Motion v = f.placement.actInv(data.v[f.parent]);
@@ -324,7 +324,7 @@ namespace tsid
                                                 const Model::FrameIndex index,
                                                 Motion & frameAcceleration) const
     {
-      assert(index<m_model.frames.size());
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(index < m_model.frames.size(), "Frame index greater than size of frame vector in model - frame may not exist");
       const Frame & f = m_model.frames[index];
       frameAcceleration = f.placement.actInv(data.a[f.parent]);
       Motion v = f.placement.actInv(data.v[f.parent]);
@@ -347,7 +347,7 @@ namespace tsid
                                           const Model::FrameIndex index,
                                           Data::Matrix6x & J) const
     {
-      assert(index<m_model.frames.size());
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(index < m_model.frames.size(), "Frame index greater than size of frame vector in model - frame may not exist");
       return pinocchio::getFrameJacobian(m_model, data, index, pinocchio::WORLD, J);
     }
     
@@ -355,7 +355,7 @@ namespace tsid
                                           const Model::FrameIndex index,
                                           Data::Matrix6x & J) const
     {
-      assert(index<m_model.frames.size());
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(index < m_model.frames.size(), "Frame index greater than size of frame vector in model - frame may not exist");
       return pinocchio::getFrameJacobian(m_model, data, index, pinocchio::LOCAL, J);
     }
 

--- a/src/solvers/solver-HQP-eiquadprog-fast.cpp
+++ b/src/solvers/solver-HQP-eiquadprog-fast.cpp
@@ -89,10 +89,9 @@ namespace tsid
     
     void SolverHQuadProgFast::retrieveQPData(const HQPData & problemData, const bool hessianRegularization)
     {
-      
       if(problemData.size() > 2)
       {
-        assert(false && "Solver not implemented for more than 2 hierarchical levels.");
+        PINOCCHIO_CHECK_INPUT_ARGUMENT(false, "Solver not implemented for more than 2 hierarchical levels.");
       }
   
       // Compute the constraint matrix sizes
@@ -161,7 +160,7 @@ namespace tsid
           const double & w = it->first;
           auto constr = it->second;
           if(!constr->isEquality())
-            assert(false && "Inequalities in the cost function are not implemented yet");
+            PINOCCHIO_CHECK_INPUT_ARGUMENT(false, "Inequalities in the cost function are not implemented yet");
           
           EIGEN_MALLOC_ALLOWED;
           m_qpData.H.noalias() += w*constr->matrix().transpose()*constr->matrix();

--- a/src/solvers/solver-HQP-eiquadprog.cpp
+++ b/src/solvers/solver-HQP-eiquadprog.cpp
@@ -79,7 +79,7 @@ void SolverHQuadProg::retrieveQPData(const HQPData & problemData, const bool /*h
 {
   if(problemData.size()>2)
   {
-    assert(false && "Solver not implemented for more than 2 hierarchical levels.");
+    PINOCCHIO_CHECK_INPUT_ARGUMENT(false, "Solver not implemented for more than 2 hierarchical levels.");
   }
 
   // Compute the constraint matrix sizes
@@ -143,7 +143,7 @@ void SolverHQuadProg::retrieveQPData(const HQPData & problemData, const bool /*h
       const double & w = it->first;
       auto constr = it->second;
       if(!constr->isEquality())
-        assert(false && "Inequalities in the cost function are not implemented yet");
+        PINOCCHIO_CHECK_INPUT_ARGUMENT(false, "Inequalities in the cost function are not implemented yet");
 
       m_qpData.H += w*constr->matrix().transpose()*constr->matrix();
       m_qpData.g -= w*(constr->matrix().transpose()*constr->vector());
@@ -216,7 +216,7 @@ void SolverHQuadProg::retrieveQPData(const HQPData & problemData, const bool /*h
       const double & w = it->first;
       auto constr = it->second;
       if(!constr->isEquality())
-        assert(false && "Inequalities in the cost function are not implemented yet");
+        PINOCCHIO_CHECK_INPUT_ARGUMENT(false, "Inequalities in the cost function are not implemented yet");
 
 	  AZ.noalias() = constr->matrix()*Z.rightCols(m_n-r);
       m_ZT_H_Z += w*AZ.transpose()*AZ;

--- a/src/solvers/solver-HQP-factory.cpp
+++ b/src/solvers/solver-HQP-factory.cpp
@@ -69,7 +69,7 @@ namespace tsid
         return new Solver_HQP_qpoases(name);
 #endif
       
-      assert(false && "Specified solver type not recognized");
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(false, "Specified solver type not recognized");
       return NULL;
     }
     

--- a/src/solvers/solver-HQP-qpmad.cpp
+++ b/src/solvers/solver-HQP-qpmad.cpp
@@ -83,7 +83,7 @@ namespace tsid
     {
       if(problemData.size()>2)
       {
-        assert(false && "Solver not implemented for more than 2 hierarchical levels.");
+        PINOCCHIO_CHECK_INPUT_ARGUMENT(false, "Solver not implemented for more than 2 hierarchical levels.");
       }
 
       // Compute the constraint matrix sizes
@@ -152,7 +152,7 @@ namespace tsid
           const double & w = it->first;
           auto constr = it->second;
           if(!constr->isEquality())
-            assert(false && "Inequalities in the cost function are not implemented yet");
+            PINOCCHIO_CHECK_INPUT_ARGUMENT(false, "Inequalities in the cost function are not implemented yet");
 
           m_H.noalias() += w*constr->matrix().transpose()*constr->matrix();
           m_g.noalias() -= w*(constr->matrix().transpose()*constr->vector());

--- a/src/solvers/solver-osqp.cpp
+++ b/src/solvers/solver-osqp.cpp
@@ -119,7 +119,7 @@ namespace tsid
 
       if(problemData.size() > 2)
           {
-            assert(false && "Solver not implemented for more than 2 hierarchical levels.");
+            PINOCCHIO_CHECK_INPUT_ARGUMENT(false, "Solver not implemented for more than 2 hierarchical levels.");
           }
           
           // Compute the constraint matrix sizes
@@ -187,7 +187,7 @@ namespace tsid
               const double & w = it->first;
               auto constr = it->second;
               if(!constr->isEquality())
-                assert(false && "Inequalities in the cost function are not implemented yet");
+                PINOCCHIO_CHECK_INPUT_ARGUMENT(false, "Inequalities in the cost function are not implemented yet");
               
               EIGEN_MALLOC_ALLOWED;
               m_qpData.H.noalias() += w*constr->matrix().transpose()*constr->matrix();

--- a/src/solvers/solver-proxqp.cpp
+++ b/src/solvers/solver-proxqp.cpp
@@ -104,7 +104,7 @@ namespace tsid
 
       if(problemData.size() > 2)
           {
-            assert(false && "Solver not implemented for more than 2 hierarchical levels.");
+            PINOCCHIO_CHECK_INPUT_ARGUMENT(false, "Solver not implemented for more than 2 hierarchical levels.");
           }
           
           // Compute the constraint matrix sizes
@@ -171,7 +171,7 @@ namespace tsid
               const double & w = it->first;
               auto constr = it->second;
               if(!constr->isEquality())
-                assert(false && "Inequalities in the cost function are not implemented yet");
+                PINOCCHIO_CHECK_INPUT_ARGUMENT(false, "Inequalities in the cost function are not implemented yet");
               
               EIGEN_MALLOC_ALLOWED;
               m_qpData.H.noalias() += w*constr->matrix().transpose()*constr->matrix();

--- a/src/tasks/task-actuation-bounds.cpp
+++ b/src/tasks/task-actuation-bounds.cpp
@@ -42,7 +42,7 @@ namespace tsid
 
     void TaskActuationBounds::mask(const Vector & m)
     {
-      assert(m.size()==m_robot.na());
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(m.size() == m_robot.na(), "The size of the mask needs to equal " + std::to_string(m_robot.na()));
       m_mask = m;
       const Vector::Index dim = static_cast<Vector::Index>(m.sum());
       Matrix S = Matrix::Zero(dim, m_robot.na());
@@ -51,7 +51,7 @@ namespace tsid
       for(unsigned int i=0; i<m.size(); i++)
         if(m(i)!=0.0)
         {
-          assert(m(i)==1.0);
+          PINOCCHIO_CHECK_INPUT_ARGUMENT(m(i) == 1.0, "The mask entries need to equal either 0.0 or 1.0");
           S(j,i) = 1.0;
           m_activeAxes(j) = i;
           j++;
@@ -71,8 +71,8 @@ namespace tsid
 
     void TaskActuationBounds::setBounds(ConstRefVector lower, ConstRefVector upper)
     {
-      assert(lower.size()==dim());
-      assert(upper.size()==dim());
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(lower.size() == dim(), "The size of the lower joint bounds vector needs to equal " + std::to_string(dim()));
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(upper.size() == dim(), "The size of the upper joint bounds vector needs to equal " + std::to_string(dim()));
       m_constraint.setLowerBound(lower);
       m_constraint.setUpperBound(upper);
     }

--- a/src/tasks/task-actuation-equality.cpp
+++ b/src/tasks/task-actuation-equality.cpp
@@ -43,7 +43,7 @@ namespace tsid
 
     void TaskActuationEquality::mask(const Vector & m)
     {
-      assert(m.size()==m_robot.na());
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(m.size() == m_robot.na(), "The size of the mask vector needs to equal " + std::to_string(m_robot.na()));
       m_mask = m;
 
       const Vector::Index dim = static_cast<Vector::Index>(m.sum());
@@ -53,7 +53,7 @@ namespace tsid
       for(unsigned int i=0; i<m.size(); i++)
         if(m(i)!=0.0)
         {
-          assert(m(i)==1.0);
+          PINOCCHIO_CHECK_INPUT_ARGUMENT(m(i) == 1.0, "Entries in the mask vector need to be either 0.0 or 1.0");
           S(j,i) = m_weights(i);
           m_activeAxes(j) = i;
           j++;
@@ -73,7 +73,7 @@ namespace tsid
     // Reference should be the same size as robot.na(), even if a mask is used (masked dof values will just be ignored)
     void TaskActuationEquality::setReference(ConstRefVector ref)
     {
-      assert(ref.size()==m_robot.na());
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(ref.size() == m_robot.na(), "The size of the reference vector needs to equal " + std::to_string(m_robot.na()));
       m_ref = ref;
 
       for(unsigned int i=0; i<m_activeAxes.size(); i++)
@@ -88,7 +88,7 @@ namespace tsid
     // Weighting vector should be the same size as robot.na(), even if a mask is used (masked dof values will just be ignored)
     void TaskActuationEquality::setWeightVector(ConstRefVector weights)
     {
-      assert(weights.size()==m_robot.na());
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(weights.size() == m_robot.na(), "The size of the weight vector needs to equal " + std::to_string(m_robot.na()));
       m_weights = weights;
 
       for(unsigned int i=0; i<m_activeAxes.size(); i++)

--- a/src/tasks/task-angular-momentum-equality.cpp
+++ b/src/tasks/task-angular-momentum-equality.cpp
@@ -55,13 +55,13 @@ namespace tsid
 
     void TaskAMEquality::Kp(ConstRefVector Kp)
     {
-      assert(Kp.size()==3);
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(Kp.size() == 3, "The size of the Kp vector needs to equal 3");
       m_Kp = Kp;
     }
 
     void TaskAMEquality::Kd(ConstRefVector Kd)
     {
-      assert(Kd.size()==3);
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(Kd.size() == 3, "The size of the Kd vector needs to equal 3");
       m_Kd = Kd;
     }
 

--- a/src/tasks/task-capture-point-inequality.cpp
+++ b/src/tasks/task-capture-point-inequality.cpp
@@ -82,14 +82,14 @@ namespace tsid
 
     void TaskCapturePointInequality::setSupportLimitsXAxis(const double x_min, const double x_max)
     {
-      assert(x_min >= x_max);
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(x_min >= x_max, "The minimum limit for x needs to be greater or equal to the maximum limit");
       m_support_limits_x(0) = x_min;
       m_support_limits_x(1) = x_max;
     }
 
     void TaskCapturePointInequality::setSupportLimitsYAxis(const double y_min, const double y_max)
     {
-      assert(y_min >= y_max);
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(y_min >= y_max, "The minimum limit for y needs to be greater or equal to the maximum limit");
       m_support_limits_y(0) = y_min;
       m_support_limits_y(1) = y_max;
     }

--- a/src/tasks/task-com-equality.cpp
+++ b/src/tasks/task-com-equality.cpp
@@ -47,7 +47,7 @@ namespace tsid
 
     void TaskComEquality::setMask(math::ConstRefVector mask)
     {
-      assert(mask.size() == 3);
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(mask.size() == 3, "The size of the mask vector needs to equal 3");
       TaskMotion::setMask(mask);
       int n = dim();
       m_constraint.resize(n, m_robot.nv());
@@ -68,13 +68,13 @@ namespace tsid
 
     void TaskComEquality::Kp(ConstRefVector Kp)
     {
-      assert(Kp.size()==3);
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(Kp.size() == 3, "The size of the Kp vector needs to equal 3");
       m_Kp = Kp;
     }
 
     void TaskComEquality::Kd(ConstRefVector Kd)
     {
-      assert(Kd.size()==3);
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(Kd.size() == 3, "The size of the Kd vector needs to equal 3");
       m_Kd = Kd;
     }
 

--- a/src/tasks/task-contact-force-equality.cpp
+++ b/src/tasks/task-contact-force-equality.cpp
@@ -49,19 +49,19 @@ const double & TaskContactForceEquality::getLeakRate() const { return m_leak_rat
 
 void TaskContactForceEquality::Kp(ConstRefVector Kp)
 {
-  assert(Kp.size()==6);
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(Kp.size() == 6, "The size of the Kp vector needs to equal 6");
   m_Kp = Kp;
 }
 
 void TaskContactForceEquality::Kd(ConstRefVector Kd)
 {
-  assert(Kd.size()==6);
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(Kd.size() == 6, "The size of the Kd vector needs to equal 6");
   m_Kd = Kd;
 }
 
 void TaskContactForceEquality::Ki(ConstRefVector Ki)
 {
-  assert(Ki.size()==6);
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(Ki.size() == 6, "The size of the Ki vector needs to equal 6");
   m_Ki = Ki;
 }
 

--- a/src/tasks/task-cop-equality.cpp
+++ b/src/tasks/task-cop-equality.cpp
@@ -102,7 +102,7 @@ const ConstraintBase & TaskCopEquality::getConstraint() const
 
 void TaskCopEquality::setReference(const Vector3 & ref)
 {
-  assert(ref.size()==3);
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(ref.size() == 3, "The size of the reference needs to equal 3");
   m_ref = ref;
 }
 

--- a/src/tasks/task-joint-bounds.cpp
+++ b/src/tasks/task-joint-bounds.cpp
@@ -35,7 +35,7 @@ namespace tsid
       m_nv(robot.nv()),
       m_na(robot.na())
     {
-      assert(dt>0.0);
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(dt > 0.0, "dt needs to be positive");
       m_v_lb = -1e10*Vector::Ones(m_na);
       m_v_ub = +1e10*Vector::Ones(m_na);
       m_a_lb = -1e10*Vector::Ones(m_na);
@@ -68,22 +68,22 @@ namespace tsid
 
     void TaskJointBounds::setTimeStep(double dt)
     {
-      assert(dt>0);
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(dt > 0.0, "dt needs to be positive");
       m_dt = dt;
     }
 
     void TaskJointBounds::setVelocityBounds(ConstRefVector lower, ConstRefVector upper)
     {
-      assert(lower.size()==m_na);
-      assert(upper.size()==m_na);
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(lower.size() == m_na, "The size of the lower velocity bounds vector needs to equal " + std::to_string(m_na));
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(upper.size() == m_na, "The size of the upper velocity bounds vector needs to equal " + std::to_string(m_na));
       m_v_lb = lower;
       m_v_ub = upper;
     }
 
     void TaskJointBounds::setAccelerationBounds(ConstRefVector lower, ConstRefVector upper)
     {
-      assert(lower.size()==m_na);
-      assert(upper.size()==m_na);
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(lower.size() == m_na, "The size of the lower acceleration bounds vector needs to equal " + std::to_string(m_na));
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(upper.size() == m_na, "The size of the upper acceleration bounds vector needs to equal " + std::to_string(m_na));
       m_a_lb = lower;
       m_a_ub = upper;
     }

--- a/src/tasks/task-joint-posVelAcc-bounds.cpp
+++ b/src/tasks/task-joint-posVelAcc-bounds.cpp
@@ -45,7 +45,7 @@ namespace tsid
       m_nv(robot.nv()),
       m_na(robot.na())
     {
-      assert(dt>0.0);
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(dt > 0.0, "dt needs to be positive");
       m_eps = 1e-10;
       m_qMin=Vector::Constant(m_na,1,-1e10);
       m_qMax=Vector::Constant(m_na,1,1e10);
@@ -125,7 +125,7 @@ namespace tsid
 
     void TaskJointPosVelAccBounds::setMask(ConstRefVector m)
     {
-      assert(m.size()==m_robot.na());
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(m.size() == m_robot.na(), "The size of the mask vector needs to equal " + std::to_string(m_robot.na()));
       m_mask = m;
       const Vector::Index dim = static_cast<Vector::Index>(m.sum());
       Matrix S = Matrix::Zero(dim, m_robot.nv());
@@ -134,7 +134,7 @@ namespace tsid
       for(unsigned int i=0; i<m.size(); i++)
         if(m(i)!=0.0)
         {
-          assert(m(i)==1.0);
+          PINOCCHIO_CHECK_INPUT_ARGUMENT(m(i) == 1.0, "Mask entries need to be either 0.0 or 1.0");
           S(j,m_robot.nv()-m_robot.na()+i) = 1.0;
           m_activeAxes(j) = i;
           j++;
@@ -160,7 +160,7 @@ namespace tsid
 
     void TaskJointPosVelAccBounds::setTimeStep(double dt)
     {
-      assert(dt>0);
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(dt > 0.0, "dt needs to be positive");
       m_dt = dt;
     }
 
@@ -170,24 +170,24 @@ namespace tsid
 
     void TaskJointPosVelAccBounds::setPositionBounds(ConstRefVector lower, ConstRefVector upper)
     {
-      assert(lower.size()==m_na);
-      assert(upper.size()==m_na);
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(lower.size() == m_na, "The size of the lower position bounds vector needs to equal " + std::to_string(m_na));
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(upper.size() == m_na, "The size of the upper position bounds vector needs to equal " + std::to_string(m_na));
       m_qMin = lower;
       m_qMax = upper;
-      m_impose_position_bounds=true;
-      m_impose_viability_bounds=true;
+      m_impose_position_bounds = true;
+      m_impose_viability_bounds = true;
     }
 
     void TaskJointPosVelAccBounds::setVelocityBounds(ConstRefVector upper)
     {
-      assert(upper.size()==m_na);
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(upper.size() == m_na, "The size of the (absolute) velocity bounds vector needs to equal " + std::to_string(m_na));
       m_dqMax = upper;
       m_impose_velocity_bounds = true;
     }
 
     void TaskJointPosVelAccBounds::setAccelerationBounds(ConstRefVector upper)
     {
-      assert(upper.size()==m_na);
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(upper.size() == m_na, "The size of the (absolute) acceleration bounds vector needs to equal " + std::to_string(m_na));
       m_ddqMax = upper;
       m_impose_acceleration_bounds = true;
     }

--- a/src/tasks/task-joint-posture.cpp
+++ b/src/tasks/task-joint-posture.cpp
@@ -53,7 +53,7 @@ namespace tsid
 
     void TaskJointPosture::setMask(ConstRefVector m)
     {
-      assert(m.size()==m_robot.na());
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(m.size()==m_robot.na(), "The size of the mask needs to equal " + std::to_string(m_robot.na()));
       m_mask = m;
       const Vector::Index dim = static_cast<Vector::Index>(m.sum());
       Matrix S = Matrix::Zero(dim, m_robot.nv());
@@ -62,7 +62,7 @@ namespace tsid
       for(unsigned int i=0; i<m.size(); i++)
         if(m(i)!=0.0)
         {
-          assert(m(i)==1.0);
+          PINOCCHIO_CHECK_INPUT_ARGUMENT(m(i)==1.0, "Valid mask values are either 0.0 or 1.0 received: " + std::to_string(m(i)));
           S(j,m_robot.nv()-m_robot.na()+i) = 1.0;
           m_activeAxes(j) = i;
           j++;
@@ -82,21 +82,21 @@ namespace tsid
 
     void TaskJointPosture::Kp(ConstRefVector Kp)
     {
-      assert(Kp.size()==m_robot.na());
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(Kp.size() == m_robot.na(), "The size of the Kp vector needs to equal " + std::to_string(m_robot.na()));
       m_Kp = Kp;
     }
 
     void TaskJointPosture::Kd(ConstRefVector Kd)
     {
-      assert(Kd.size()==m_robot.na());
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(Kd.size() == m_robot.na(), "The size of the Kd vector needs to equal " + std::to_string(m_robot.na()));
       m_Kd = Kd;
     }
 
     void TaskJointPosture::setReference(const TrajectorySample & ref)
     {
-      assert(ref.getValue().size()==m_robot.nq_actuated());
-      assert(ref.getDerivative().size()==m_robot.na());
-      assert(ref.getSecondDerivative().size()==m_robot.na());
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(ref.getValue().size() == m_robot.nq_actuated(), "The size of the reference value vector needs to equal " + std::to_string(m_robot.nq_actuated()));
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(ref.getDerivative().size() == m_robot.na(), "The size of the reference value derivative vector needs to equal " + std::to_string(m_robot.na()));
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(ref.getSecondDerivative().size() == m_robot.na(), "The size of the reference value second derivative vector needs to equal " + std::to_string(m_robot.na()));
       m_ref = ref;
     }
 

--- a/src/tasks/task-se3-equality.cpp
+++ b/src/tasks/task-se3-equality.cpp
@@ -36,7 +36,7 @@ namespace tsid
       m_constraint(name, 6, robot.nv()),
       m_ref(12, 6)
     {
-      assert(m_robot.model().existFrame(frameName));
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(m_robot.model().existFrame(frameName), "The frame with name '" + frameName + "' does not exist");
       m_frame_id = m_robot.model().getFrameId(frameName);
 
       m_v_ref.setZero();
@@ -84,13 +84,13 @@ namespace tsid
 
     void TaskSE3Equality::Kp(ConstRefVector Kp)
     {
-      assert(Kp.size()==6);
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(Kp.size() == 6, "The size of the Kp vector needs to equal 6");
       m_Kp = Kp;
     }
 
     void TaskSE3Equality::Kd(ConstRefVector Kd)
     {
-      assert(Kd.size()==6);
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(Kd.size() == 6, "The size of the Kd vector needs to equal 6");
       m_Kd = Kd;
     }
 
@@ -99,8 +99,8 @@ namespace tsid
       m_ref = ref;
 TSID_DISABLE_WARNING_PUSH
 TSID_DISABLE_WARNING_DEPRECATED
-      assert(ref.pos.size() == 12);
-      m_M_ref.translation( ref.pos.head<3>());
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(ref.pos.size() == 12, "The size of the reference vector needs to be 12");
+      m_M_ref.translation(ref.pos.head<3>());
       m_M_ref.rotation(MapMatrix3(&ref.pos(3), 3, 3));
 TSID_DISABLE_WARNING_POP
       m_v_ref = Motion(ref.getDerivative());

--- a/tests/hqp_solvers.cpp
+++ b/tests/hqp_solvers.cpp
@@ -327,32 +327,32 @@ BOOST_AUTO_TEST_CASE ( test_eiquadprog_classic_vs_rt_vs_fast_vs_proxqp)
     for(unsigned int j=0; j<nsmooth; j++)
     {
       getProfiler().start(PROFILE_EIQUADPROG_FAST);
-      const HQPOutput & output_fast = solver_fast->solve(HQPData);
+      (void) solver_fast->solve(HQPData);
       getProfiler().stop(PROFILE_EIQUADPROG_FAST);
 
       getProfiler().start(PROFILE_EIQUADPROG_RT);
-      const HQPOutput & output_rt = solver_rt->solve(HQPData);
+      (void) solver_rt->solve(HQPData);
       getProfiler().stop(PROFILE_EIQUADPROG_RT);
 
       getProfiler().start(PROFILE_EIQUADPROG);
-      const HQPOutput & output    = solver->solve(HQPData);
+      (void) solver->solve(HQPData);
       getProfiler().stop(PROFILE_EIQUADPROG);
 
     #ifdef TSID_WITH_PROXSUITE
       getProfiler().start(PROFILE_PROXQP);
-      const HQPOutput & output_proxqp = solver_proxqp->solve(HQPData);
+      (void) solver_proxqp->solve(HQPData);
       getProfiler().stop(PROFILE_PROXQP);
     #endif
 
     #ifdef TSID_WITH_OSQP
       getProfiler().start(PROFILE_OSQP);
-      const HQPOutput & output_osqp = solver_osqp->solve(HQPData);
+      (void) solver_osqp->solve(HQPData);
       getProfiler().stop(PROFILE_OSQP);
     #endif
 
     #ifdef TSID_QPMAD_FOUND
       getProfiler().start(PROFILE_QPMAD);
-      const HQPOutput & output_qpmad = solver_qpmad->solve(HQPData);
+      (void) solver_qpmad->solve(HQPData);
       getProfiler().stop(PROFILE_QPMAD);
     #endif
     }

--- a/tests/tsid-formulation.cpp
+++ b/tests/tsid-formulation.cpp
@@ -119,7 +119,7 @@ class StandardRomeoInvDynCtrl
 
     pinocchio::srdf::loadReferenceConfigurations(robot->model(),srdfFileName,false);
 
-    const unsigned int nv = robot->nv();
+    const unsigned int nv{static_cast<unsigned int>(robot->nv())};
     q = neutral(robot->model());
     std::cout << "q: " << q.transpose() << std::endl;
     q(2) += 0.84;


### PR DESCRIPTION
This PR adds explicit checking of input argument sizes etc. as in Pinocchio using the Pinocchio macros. Given that Pinocchio is a necessary requirement, I re-used the macros from Pinocchio rather than copy-pasting them into TSID. This is particularly important for the Python bindings which allowed wrong values to be passed in from users.

I also fixed missing virtual destructors which lead to issues when destructing TSID problems.

I've also flipped the default option for generating and installing the documentation in line with EigenPy and Pinocchio