### PR TITLE
Implement missing argument check and fix warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,11 +35,13 @@ option(EIGEN_NO_AUTOMATIC_RESIZING
 option(BUILD_WITH_PROXQP "Support using the proxqp solver" OFF)
 option(BUILD_WITH_OSQP "Support using the osqp solver" OFF)
 
-# With pos, vel, acc awaiting renaming (e.g. in trajectory-base), we are producing a ton of deprecation warnings.
-# Ignoring them for now; remove this once pos, vel, acc are renamed.
+# With pos, vel, acc awaiting renaming (e.g. in trajectory-base), we are
+# producing a ton of deprecation warnings. Ignoring them for now; remove this
+# once pos, vel, acc are renamed.
 add_definitions(-Wno-deprecated)
 
-# We frequently convert between signed and unsigned integers for Eigen::Index. Ignore them for now.
+# We frequently convert between signed and unsigned integers for Eigen::Index.
+# Ignore them for now.
 add_definitions(-Wno-sign-conversion)
 
 # Project configuration

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,13 @@ option(EIGEN_NO_AUTOMATIC_RESIZING
 option(BUILD_WITH_PROXQP "Support using the proxqp solver" OFF)
 option(BUILD_WITH_OSQP "Support using the osqp solver" OFF)
 
+# With pos, vel, acc awaiting renaming (e.g. in trajectory-base), we are producing a ton of deprecation warnings.
+# Ignoring them for now; remove this once pos, vel, acc are renamed.
+add_definitions(-Wno-deprecated)
+
+# We frequently convert between signed and unsigned integers for Eigen::Index. Ignore them for now.
+add_definitions(-Wno-sign-conversion)
+
 # Project configuration
 if(NOT INSTALL_PYTHON_INTERFACE_ONLY)
   set(PROJECT_USE_CMAKE_EXPORT TRUE)

--- a/include/tsid/tasks/task-contact-force.hpp
+++ b/include/tsid/tasks/task-contact-force.hpp
@@ -18,6 +18,7 @@
 #ifndef __invdyn_task_contact_force_hpp__
 #define __invdyn_task_contact_force_hpp__
 
+#include <tsid/deprecated.hh>
 #include <tsid/tasks/task-base.hpp>
 #include <tsid/formulations/contact-level.hpp>
 #include <memory>
@@ -42,11 +43,14 @@ namespace tsid
        * argument the list of active contacts. This can be needed for force tasks that
        * involve all contacts, such as the CoP task.
        */
+TSID_DISABLE_WARNING_PUSH
+TSID_DISABLE_WARNING(-Woverloaded-virtual)
       virtual const ConstraintBase & compute(const double t,
                                              ConstRefVector q,
                                              ConstRefVector v,
                                              Data & data,
                                              const std::vector<std::shared_ptr<ContactLevel> >  *contacts) = 0;
+TSID_DISABLE_WARNING_POP
 
       /**
        * Return the name of the contact associated to this task if this task is associated to a specific contact.

--- a/src/contacts/contact-point.cpp
+++ b/src/contacts/contact-point.cpp
@@ -109,8 +109,7 @@ void ContactPoint::setRegularizationTaskWeightVector(ConstRefVector & w)
 
 void ContactPoint::updateForceRegularizationTask()
 {
-  typedef Eigen::Matrix<double,3,3> Matrix3;
-  Matrix3 A = Matrix3::Zero();
+  Eigen::Matrix3d A = Eigen::Matrix3d::Zero();
   A.diagonal() = m_weightForceRegTask;
   m_forceRegTask.setMatrix(A);
   m_forceRegTask.setVector(A*m_fRef);
@@ -196,6 +195,7 @@ bool ContactPoint::setMaxNormalForce(const double maxNormalForce)
 
 void ContactPoint::setForceReference(ConstRefVector & f_ref)
 {
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(f_ref.size() == 3, "The size of the force reference needs to equal 3");
   m_fRef = f_ref;
   updateForceRegularizationTask();
 }


### PR DESCRIPTION
Adds input argument check to the ContactPoint task.

Fixes warnings by ignoring the three remaining types of warnings - two project-wide, one where it occurs.