### PR TITLE
Fix solver python test

### DIFF
--- a/exercizes/notebooks/Installation process.ipynb
+++ b/exercizes/notebooks/Installation process.ipynb
@@ -1,5 +1,5 @@
 {
- "cells": [
+  "cells": [
   {
    "cell_type": "markdown",
    "metadata": {},

--- a/exercizes/notebooks/ex_0_joint_space_inverse_dynamics_arm.ipynb
+++ b/exercizes/notebooks/ex_0_joint_space_inverse_dynamics_arm.ipynb
@@ -1,5 +1,5 @@
 {
- "cells": [
+  "cells": [
   {
    "cell_type": "markdown",
    "metadata": {},

--- a/exercizes/notebooks/ex_1_com_sin_track_talos.ipynb
+++ b/exercizes/notebooks/ex_1_com_sin_track_talos.ipynb
@@ -1,5 +1,5 @@
 {
- "cells": [
+  "cells": [
   {
    "cell_type": "markdown",
    "metadata": {},

--- a/exercizes/notebooks/ex_3_biped_balance_with_gui.ipynb
+++ b/exercizes/notebooks/ex_3_biped_balance_with_gui.ipynb
@@ -1,5 +1,5 @@
 {
- "cells": [
+  "cells": [
   {
    "cell_type": "code",
    "execution_count": null,

--- a/tests/python/test_Solvers.py
+++ b/tests/python/test_Solvers.py
@@ -5,6 +5,8 @@ print("")
 print("Test Solvers")
 print("")
 
+np.random.seed(0)
+
 EPS = 1e-3
 nTest = 100
 n = 60
@@ -38,6 +40,7 @@ print("Adding eiquadprog to list of solvers to test")
 
 try:
     solver_proxqp = tsid.SolverProxQP("proxqp solver")
+    solver_proxqp.set_epsilon_absolute(1e-6)
     solver_proxqp.resize(n, neq, nin)
     solver_list.append(("proxqp", solver_proxqp))
     print("Adding proxqp to list of solvers to test")
@@ -47,6 +50,8 @@ except AttributeError:
 
 try:
     solver_osqp = tsid.SolverOSQP("osqp solver")
+    solver_osqp.set_epsilon_absolute(1e-6)
+    solver_osqp.set_maximum_iterations(10_000)
     solver_osqp.resize(n, neq, nin)
     solver_list.append(("osqp", solver_osqp))
     print("Adding osqp to list of solvers to test")
@@ -59,7 +64,8 @@ A1 = np.random.rand(n, n) + 0.001 * np.eye(n)
 b1 = np.random.rand(n)
 cost = tsid.ConstraintEquality("c1", A1, b1)
 
-x = np.linalg.inv(A1).dot(b1)
+x = np.linalg.solve(A1, b1)
+
 A_in = np.random.rand(nin, n)
 A_lb = np.random.rand(nin) * NORMAL_DISTR_VAR
 A_ub = np.random.rand(nin) * NORMAL_DISTR_VAR
@@ -110,6 +116,7 @@ for name, solver in solver_list:
 
         HQPoutput = solver.solve(HQPData)
 
+        assert HQPoutput.status == 0  # HQP_STATUS_OPTIMAL = 0
         assert np.linalg.norm(A_eq.dot(HQPoutput.x) - b_eq, 2) < EPS
         assert (A_in.dot(HQPoutput.x) <= A_ub + EPS).all()
         assert (A_in.dot(HQPoutput.x) > A_lb - EPS).all()


### PR DESCRIPTION
In this PR, I check the returned status from the solver to make sure that the random problems were actually solved successfully. 
I fixed a random seed, like this the different CI runs are comparable. 

In the past, we had problems with osqp which did not pass the Python test, see #215. Testing on my local machine showed that osqp is reaching the maximum number of iterations. Therefore, I increased it and added the check for the status.