### PR TITLE
CMake: fix python setup

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -117,5 +117,5 @@ install(
 set(PYTHON_FILES __init__.py)
 
 foreach(python ${PYTHON_FILES})
-  python_install(${PROJECT_NAME} ${python} ${${PYWRAP}_INSTALL_DIR})
+  python_install_on_site(${PROJECT_NAME} ${python})
 endforeach(python)


### PR DESCRIPTION
fix #243

I broke that in latest release, sorry.

This should have been caught by the Nix CI which try to import the python package after installation, but actually since [PEP 420](https://peps.python.org/pep-0420/) that `tsid` folder without a `__init__.py` file was considered a valid namespace package, so no error were raised.

It also  should have been caught by my robotpkg tests during the release process, but this did only raise a warning in the test setup, while raising a fatal error at the DEB package generation step, which is not part of the tests.