### PR TITLE
[fix] missing const in arguments of `RobotWrapper.set_rotor_inertia` and `RobotWrapper.set_gear_ratios` python bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix missing `const` specifier in python bindings for methods `RobotInertia.set_rotor_inertia()`
+ and `RobotInertia.set_gear_ratios()`
 ## [1.7.1] - 2024-08-26
 
 - Fix a typo in ex_4_walking

--- a/include/tsid/bindings/python/robots/robot-wrapper.hpp
+++ b/include/tsid/bindings/python/robots/robot-wrapper.hpp
@@ -129,7 +129,8 @@ struct RobotPythonVisitor
   static Eigen::VectorXd gear_ratios(const Robot &self) {
     return self.gear_ratios();
   }
-  static bool set_rotor_inertias(Robot &self, const Eigen::VectorXd &rotor_inertias) {
+  static bool set_rotor_inertias(Robot &self,
+                                 const Eigen::VectorXd &rotor_inertias) {
     return self.rotor_inertias(rotor_inertias);
   }
   static bool set_gear_ratios(Robot &self, const Eigen::VectorXd &gear_ratios) {

--- a/include/tsid/bindings/python/robots/robot-wrapper.hpp
+++ b/include/tsid/bindings/python/robots/robot-wrapper.hpp
@@ -129,10 +129,10 @@ struct RobotPythonVisitor
   static Eigen::VectorXd gear_ratios(const Robot &self) {
     return self.gear_ratios();
   }
-  static bool set_rotor_inertias(Robot &self, Eigen::VectorXd &rotor_inertias) {
+  static bool set_rotor_inertias(Robot &self, const Eigen::VectorXd &rotor_inertias) {
     return self.rotor_inertias(rotor_inertias);
   }
-  static bool set_gear_ratios(Robot &self, Eigen::VectorXd &gear_ratios) {
+  static bool set_gear_ratios(Robot &self, const Eigen::VectorXd &gear_ratios) {
     return self.gear_ratios(gear_ratios);
   }
 

--- a/tests/python/test_RobotWrapper.py
+++ b/tests/python/test_RobotWrapper.py
@@ -37,8 +37,9 @@ print(robot.com(data))
 base_mass_matrix = robot.mass(data)
 
 # Adding motor inertia
-rotor_inertia = np.random.uniform(0, 1, size=(robot.nq - 7))
-gear_ratio = np.random.uniform(0, 1, size=(robot.nq - 7))
+rng = np.random.default_rng()
+rotor_inertia = rng.uniform(0, 1, size=(robot.nq - 7))
+gear_ratio = rng.uniform(0, 1, size=(robot.nq - 7))
 expected_inertia = rotor_inertia * gear_ratio**2
 print(f"Expected motors inertia: {expected_inertia}")
 

--- a/tests/python/test_RobotWrapper.py
+++ b/tests/python/test_RobotWrapper.py
@@ -50,7 +50,9 @@ robot.computeAllTerms(data, q, v)
 mass_matrix_with_motor_inertia = robot.mass(data)
 
 # Assert that mass matrices are different by motor's inertia
-np.testing.assert_allclose(np.diag(mass_matrix_with_motor_inertia - base_mass_matrix)[6:], expected_inertia)
+np.testing.assert_allclose(
+    np.diag(mass_matrix_with_motor_inertia - base_mass_matrix)[6:], expected_inertia
+)
 
 
 print("All test is done")

--- a/tests/python/test_RobotWrapper.py
+++ b/tests/python/test_RobotWrapper.py
@@ -29,9 +29,28 @@ ub[3:7] = 1.0 * np.ones(4)
 q = se3.randomConfiguration(robot.model(), lb, ub)
 print(q.transpose())
 
+
 data = robot.data()
 v = np.ones(robot.nv)
 robot.computeAllTerms(data, q, v)
 print(robot.com(data))
+base_mass_matrix = robot.mass(data)
+
+# Adding motor inertia
+rotor_inertia = np.random.uniform(0, 1, size=(robot.nq - 7))
+gear_ratio = np.random.uniform(0, 1, size=(robot.nq - 7))
+expected_inertia = rotor_inertia * gear_ratio**2
+print(f"Expected motors inertia: {expected_inertia}")
+
+robot.set_rotor_inertias(rotor_inertia)
+robot.set_gear_ratios(gear_ratio)
+
+robot.computeAllTerms(data, q, v)
+
+mass_matrix_with_motor_inertia = robot.mass(data)
+
+# Assert that mass matrices are different by motor's inertia
+np.testing.assert_allclose(np.diag(mass_matrix_with_motor_inertia - base_mass_matrix)[6:], expected_inertia)
+
 
 print("All test is done")


### PR DESCRIPTION
This MR adds missing `const` identifier to the arguments of two methods of `RobotWrapper`: `set_rotor_inertia` and `set_gear_ratios` in python bingings. This problem practically disallowed to use motor inertia in python bindings.

Right now, this functionality does not work, and an attempt to run the simplest example:
```python
from copy import deepcopy

import numpy as np
import pinocchio as pin
import tsid
from robot_descriptions.iiwa7_description import URDF_PATH

pin_model = pin.buildModelFromUrdf(URDF_PATH)
robot = tsid.RobotWrapper(pin_model, False)

robot.set_gear_ratios(np.ones(12))
robot.set_rotor_inertias(np.ones(12))

print(robot.rotor_inertias)
print(robot.gear_ratios)
```

results in:
```bash
Boost.Python.ArgumentError: Python argument types in
    RobotWrapper.set_gear_ratios(RobotWrapper, numpy.ndarray)
did not match C++ signature:
    set_gear_ratios(tsid::robots::RobotWrapper {lvalue}, Eigen::Matrix<double, -1, 1, 0, -1, 1> {lvalue} gear ratio vector)
```
