### PR TITLE
Fix removeRigidContact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix value of nEq when removeRigidContact for contact with priority > 0
+
 ## [1.8.0] - 2025-03-29
 
 - Fix missing `const` specifier in python bindings for methods `RobotInertia.set_rotor_inertia()`

--- a/include/tsid/formulations/inverse-dynamics-formulation-acc-force.hpp
+++ b/include/tsid/formulations/inverse-dynamics-formulation-acc-force.hpp
@@ -105,6 +105,7 @@ class InverseDynamicsFormulationAccForce
   Vector getContactForces(const std::string& name, const HQPOutput& sol);
   bool getContactForces(const std::string& name, const HQPOutput& sol,
                         RefVector f) override;
+  unsigned int getTaskPriority(const std::string& name) override;
 
  public:
   template <class TaskLevelPointer>

--- a/include/tsid/formulations/inverse-dynamics-formulation-base.hpp
+++ b/include/tsid/formulations/inverse-dynamics-formulation-base.hpp
@@ -157,6 +157,8 @@ class InverseDynamicsFormulationBase {
   virtual bool getContactForces(const std::string& name, const HQPOutput& sol,
                                 RefVector f) = 0;
 
+  virtual unsigned int getTaskPriority(const std::string& name) = 0;
+
  protected:
   std::string m_name;
   RobotWrapper m_robot;

--- a/tests/tsid-formulation.cpp
+++ b/tests/tsid-formulation.cpp
@@ -322,6 +322,15 @@ BOOST_AUTO_TEST_CASE(test_invdyn_formulation_acc_force_remove_contact) {
     CHECK_LESS_THAN(v.norm(), 1e6);
   }
 
+  // Removing contact constraint should decrease nb of equality by 6
+  int nEq = tsid->nEq();
+  tsid->removeRigidContact("contact_rfoot");
+  nEq -= 6;
+  BOOST_CHECK_EQUAL(nEq, tsid->nEq());
+  tsid->removeRigidContact("contact_lfoot");
+  nEq -= 6;
+  BOOST_CHECK_EQUAL(nEq, tsid->nEq());
+
   delete solver;
   cout << "\n### TEST FINISHED ###\n";
   PRINT_VECTOR(v);

--- a/tests/tsid-formulation.cpp
+++ b/tests/tsid-formulation.cpp
@@ -573,6 +573,7 @@ BOOST_AUTO_TEST_CASE(test_contact_point_invdyn_formulation_acc_force) {
   Vector3 contactNormal = Vector3::UnitZ();
   std::vector<std::shared_ptr<ContactPoint>> contacts(4);
 
+  int nEq = tsid->nEq();
   for (int i = 0; i < 4; i++) {
     auto cp = std::make_shared<ContactPoint>("contact_" + contactFrames[i],
                                              robot, contactFrames[i],
@@ -583,6 +584,9 @@ BOOST_AUTO_TEST_CASE(test_contact_point_invdyn_formulation_acc_force) {
         robot.framePosition(data, robot.model().getFrameId(contactFrames[i])));
     cp->useLocalFrame(false);
     tsid->addRigidContact(*cp, w_forceReg, 1.0, 1);
+
+    // Adding rigid contact as cost should not change nb of equalities
+    BOOST_CHECK_EQUAL(nEq, tsid->nEq());
 
     contacts[i] = cp;
   }
@@ -650,10 +654,15 @@ BOOST_AUTO_TEST_CASE(test_contact_point_invdyn_formulation_acc_force) {
     CHECK_LESS_THAN(v.norm(), 1e6);
   }
 
+  nEq = tsid->nEq();
   for (int i = 0; i < 4; i++) {
     Eigen::Matrix<double, 3, 1> f;
     tsid->getContactForces(contacts[i]->name(), *sol, f);
     cout << contacts[i]->name() << " force:" << f.transpose() << endl;
+
+    // Removing rigid contact (added as cost) should not change nb of equalities
+    tsid->removeRigidContact(contacts[i]->name());
+    BOOST_CHECK_EQUAL(nEq, tsid->nEq());
   }
 
   delete solver;


### PR DESCRIPTION
Hello,

I noticed an error while using rigid contact, the number of equalities is decremented no matter what when removeRigidContact is called.

https://github.com/stack-of-tasks/tsid/blob/6e0293b3c28e395aa5cc3da162dbeb7954c5561e/src/formulations/inverse-dynamics-formulation-acc-force.cpp#L559

However, is the motion task has been added with a priority > 0, it shouldn't affect the number of equalities

https://github.com/stack-of-tasks/tsid/blob/6e0293b3c28e395aa5cc3da162dbeb7954c5561e/src/formulations/inverse-dynamics-formulation-acc-force.cpp#L82

So nEq was underflowing in our walking scenario where we constantly break and make contact.

Here is a small fix 