### PR TITLE
Fix inverted condition in setSupportLimitsXAxis/YAxis

### DIFF
--- a/src/tasks/task-capture-point-inequality.cpp
+++ b/src/tasks/task-capture-point-inequality.cpp
@@ -58,18 +58,20 @@ const ConstraintBase& TaskCapturePointInequality::getConstraint() const {
 
 void TaskCapturePointInequality::setSupportLimitsXAxis(const double x_min,
                                                        const double x_max) {
-  PINOCCHIO_CHECK_INPUT_ARGUMENT(x_min <= x_max,
-                                 "The minimum limit for x needs to be less than "
-                                 "or equal to the maximum limit");
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(
+      x_min <= x_max,
+      "The minimum limit for x needs to be less than "
+      "or equal to the maximum limit");
   m_support_limits_x(0) = x_min;
   m_support_limits_x(1) = x_max;
 }
 
 void TaskCapturePointInequality::setSupportLimitsYAxis(const double y_min,
                                                        const double y_max) {
-  PINOCCHIO_CHECK_INPUT_ARGUMENT(y_min <= y_max,
-                                 "The minimum limit for y needs to be less than "
-                                 "or equal to the maximum limit");
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(
+      y_min <= y_max,
+      "The minimum limit for y needs to be less than "
+      "or equal to the maximum limit");
   m_support_limits_y(0) = y_min;
   m_support_limits_y(1) = y_max;
 }

--- a/src/tasks/task-capture-point-inequality.cpp
+++ b/src/tasks/task-capture-point-inequality.cpp
@@ -58,8 +58,8 @@ const ConstraintBase& TaskCapturePointInequality::getConstraint() const {
 
 void TaskCapturePointInequality::setSupportLimitsXAxis(const double x_min,
                                                        const double x_max) {
-  PINOCCHIO_CHECK_INPUT_ARGUMENT(x_min >= x_max,
-                                 "The minimum limit for x needs to be greater "
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(x_min <= x_max,
+                                 "The minimum limit for x needs to be less than "
                                  "or equal to the maximum limit");
   m_support_limits_x(0) = x_min;
   m_support_limits_x(1) = x_max;
@@ -67,8 +67,8 @@ void TaskCapturePointInequality::setSupportLimitsXAxis(const double x_min,
 
 void TaskCapturePointInequality::setSupportLimitsYAxis(const double y_min,
                                                        const double y_max) {
-  PINOCCHIO_CHECK_INPUT_ARGUMENT(y_min >= y_max,
-                                 "The minimum limit for y needs to be greater "
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(y_min <= y_max,
+                                 "The minimum limit for y needs to be less than "
                                  "or equal to the maximum limit");
   m_support_limits_y(0) = y_min;
   m_support_limits_y(1) = y_max;

--- a/tests/tasks.cpp
+++ b/tests/tasks.cpp
@@ -15,6 +15,7 @@
 #include <tsid/tasks/task-joint-posture.hpp>
 #include <tsid/tasks/task-joint-bounds.hpp>
 #include <tsid/tasks/task-joint-posVelAcc-bounds.hpp>
+#include <tsid/tasks/task-capture-point-inequality.hpp>
 
 #include <tsid/trajectories/trajectory-se3.hpp>
 #include <tsid/trajectories/trajectory-euclidian.hpp>
@@ -341,6 +342,64 @@ BOOST_AUTO_TEST_CASE(test_task_joint_posVelAcc_bounds) {
     BOOST_REQUIRE(isFinite(v));
     BOOST_REQUIRE(isFinite(q));
     t += dt;
+  }
+}
+
+BOOST_AUTO_TEST_CASE(test_task_capture_point_inequality) {
+  cout << "\n\n*********** TEST TASK CAPTURE POINT INEQUALITY ***********\n";
+  vector<string> package_dirs;
+  package_dirs.push_back(romeo_model_path);
+  string urdfFileName = package_dirs[0] + "/urdf/romeo.urdf";
+  RobotWrapper robot(urdfFileName, package_dirs,
+                     pinocchio::JointModelFreeFlyer(), false);
+
+  const double dt = 0.001;
+  TaskCapturePointInequality task("task-capture-point", robot, dt);
+
+  // Test setSupportLimitsXAxis with valid inputs (x_min <= x_max)
+  BOOST_CHECK_NO_THROW(task.setSupportLimitsXAxis(-0.1, 0.1));
+  BOOST_CHECK_NO_THROW(task.setSupportLimitsXAxis(0.0, 0.0));  // equal is valid
+  BOOST_CHECK_NO_THROW(task.setSupportLimitsXAxis(-0.5, 0.5));
+
+  // Test setSupportLimitsYAxis with valid inputs (y_min <= y_max)
+  BOOST_CHECK_NO_THROW(task.setSupportLimitsYAxis(-0.1, 0.1));
+  BOOST_CHECK_NO_THROW(task.setSupportLimitsYAxis(0.0, 0.0));  // equal is valid
+  BOOST_CHECK_NO_THROW(task.setSupportLimitsYAxis(-0.3, 0.3));
+
+  // Test setSupportLimitsXAxis with invalid inputs (x_min > x_max)
+  BOOST_CHECK_THROW(task.setSupportLimitsXAxis(0.1, -0.1),
+                    std::invalid_argument);
+
+  // Test setSupportLimitsYAxis with invalid inputs (y_min > y_max)
+  BOOST_CHECK_THROW(task.setSupportLimitsYAxis(0.1, -0.1),
+                    std::invalid_argument);
+
+  // Test setSafetyMargin
+  task.setSafetyMargin(0.01, 0.01);
+
+  // Test compute
+  task.setSupportLimitsXAxis(-0.1, 0.1);
+  task.setSupportLimitsYAxis(-0.05, 0.05);
+  task.setSafetyMargin(0.01, 0.01);
+
+  VectorXd q = neutral(robot.model());
+  q(2) += 0.84;
+  VectorXd v = VectorXd::Zero(robot.nv());
+  pinocchio::Data data(robot.model());
+
+  double t = 0.0;
+  robot.computeAllTerms(data, q, v);
+  const ConstraintBase& constraint = task.compute(t, q, v, data);
+  BOOST_CHECK(constraint.rows() == 2);
+  BOOST_CHECK(static_cast<tsid::math::Index>(constraint.cols()) ==
+              static_cast<tsid::math::Index>(robot.nv()));
+  BOOST_REQUIRE(isFinite(constraint.matrix()));
+  BOOST_REQUIRE(isFinite(constraint.lowerBound()));
+  BOOST_REQUIRE(isFinite(constraint.upperBound()));
+
+  // Lower bound should be <= upper bound
+  for (int i = 0; i < 2; i++) {
+    BOOST_CHECK(constraint.lowerBound()(i) <= constraint.upperBound()(i));
   }
 }
 


### PR DESCRIPTION
## Summary

- Fix the inverted condition in `setSupportLimitsXAxis` and `setSupportLimitsYAxis` in `TaskCapturePointInequality`
- The `PINOCCHIO_CHECK_INPUT_ARGUMENT` macro throws when the condition is `false`, but the original code used `x_min >= x_max` instead of `x_min <= x_max`, causing valid inputs (e.g., `(-0.1, 0.1)`) to throw `std::invalid_argument` while invalid inputs (e.g., `(0.1, -0.1)`) passed through silently
- Add unit test for `TaskCapturePointInequality` covering input validation and basic `compute` behavior

## Details

`PINOCCHIO_CHECK_INPUT_ARGUMENT(condition, message)` expands to:

```cpp
if (!(condition)) { throw std::invalid_argument(message); }
```

The original code:
```cpp
PINOCCHIO_CHECK_INPUT_ARGUMENT(x_min >= x_max, ...);  // wrong
```

The fix:
```cpp
PINOCCHIO_CHECK_INPUT_ARGUMENT(x_min <= x_max, ...);  // correct
```

The error message was also updated from "greater" to "less than" to match the corrected logic.

## Test plan

- [x] Added `test_task_capture_point_inequality` in `tests/tasks.cpp`
  - Valid inputs (`min <= max`) do not throw
  - Equal values (`min == max`) do not throw
  - Invalid inputs (`min > max`) throw `std::invalid_argument`
  - `compute` returns finite matrix, lower/upper bounds, and `lowerBound <= upperBound`
- [x] All 9 existing tests continue to pass