### PR TITLE
Daqp interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ option(
 )
 option(BUILD_WITH_PROXQP "Support using the proxqp solver" OFF)
 option(BUILD_WITH_OSQP "Support using the osqp solver" OFF)
+option(BUILD_WITH_DAQP "Support using the DAQP hierarchical QP solver" OFF)
 
 # With pos, vel, acc awaiting renaming (e.g. in trajectory-base), we are
 # producing a ton of deprecation warnings. Ignoring them for now; remove this
@@ -109,6 +110,10 @@ endif(BUILD_PYTHON_INTERFACE)
 
 add_project_dependency(pinocchio 2.3.1 REQUIRED)
 add_project_dependency(eiquadprog 1.1.3 REQUIRED)
+
+if(BUILD_WITH_DAQP)
+    add_project_dependency(daqp REQUIRED CONFIG)
+endif()
 
 find_package(qpmad QUIET) # optional
 if(qpmad_FOUND)
@@ -213,6 +218,13 @@ if(BUILD_WITH_OSQP)
     )
 endif()
 
+if(BUILD_WITH_DAQP)
+    list(
+        APPEND ${PROJECT_NAME}_SOLVERS_HEADERS
+        include/tsid/solvers/solver-HQP-daqp.hpp
+    )
+endif()
+
 if(qpmad_FOUND)
     list(
         APPEND ${PROJECT_NAME}_SOLVERS_HEADERS
@@ -306,6 +318,10 @@ if(BUILD_WITH_OSQP)
     list(APPEND ${PROJECT_NAME}_SOLVERS_SOURCES src/solvers/solver-osqp.cpp)
 endif()
 
+if(BUILD_WITH_DAQP)
+    list(APPEND ${PROJECT_NAME}_SOLVERS_SOURCES src/solvers/solver-HQP-daqp.cpp)
+endif()
+
 if(qpmad_FOUND)
     list(
         APPEND ${PROJECT_NAME}_SOLVERS_SOURCES
@@ -361,6 +377,15 @@ if(NOT BUILD_STANDALONE_PYTHON_INTERFACE)
     if(BUILD_WITH_OSQP)
         target_link_libraries(${PROJECT_NAME} PUBLIC OsqpEigen::OsqpEigen)
         target_compile_definitions(${PROJECT_NAME} PUBLIC -DTSID_WITH_OSQP)
+    endif()
+
+    if(BUILD_WITH_DAQP)
+        target_compile_definitions(${PROJECT_NAME} PUBLIC -DTSID_WITH_DAQP)
+        if(TARGET daqp::daqp)
+            target_link_libraries(${PROJECT_NAME} PUBLIC daqp::daqp)
+        else()
+            target_link_libraries(${PROJECT_NAME} PUBLIC daqp)
+        endif()
     endif()
 
     if(qpmad_FOUND)

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -55,6 +55,7 @@ set(${PYWRAP}_HEADERS
     ../../include/tsid/bindings/python/solvers/HQPData.hpp
     ../../include/tsid/bindings/python/solvers/HQPOutput.hpp
     ../../include/tsid/bindings/python/solvers/solver-HQP-eiquadprog.hpp
+    ../../include/tsid/bindings/python/solvers/solver-HQP-daqp.hpp
     ../../include/tsid/bindings/python/solvers/solver-osqp.hpp
     ../../include/tsid/bindings/python/solvers/solver-proxqp.hpp
     ../../include/tsid/bindings/python/tasks/expose-tasks.hpp

--- a/bindings/python/solvers/solver-HQP-eiquadprog.cpp
+++ b/bindings/python/solvers/solver-HQP-eiquadprog.cpp
@@ -26,5 +26,12 @@ void exposeSolverOSQP() {
   SolverOSQPPythonVisitor<tsid::solvers::SolverOSQP>::expose("SolverOSQP");
 #endif
 }
+
+void exposeSolverDAQP() {
+#ifdef TSID_WITH_DAQP
+  SolverDAQPPythonVisitor<tsid::solvers::SolverHQPDAQP>::expose(
+      "SolverHQPDAQP");
+#endif
+}
 }  // namespace python
 }  // namespace tsid

--- a/include/tsid/bindings/python/solvers/expose-solvers.hpp
+++ b/include/tsid/bindings/python/solvers/expose-solvers.hpp
@@ -25,6 +25,9 @@
 #ifdef TSID_WITH_OSQP
 #include "tsid/bindings/python/solvers/solver-osqp.hpp"
 #endif
+#ifdef TSID_WITH_DAQP
+#include "tsid/bindings/python/solvers/solver-HQP-daqp.hpp"
+#endif
 #include "tsid/bindings/python/solvers/HQPData.hpp"
 #include "tsid/bindings/python/solvers/HQPOutput.hpp"
 namespace tsid {
@@ -32,6 +35,7 @@ namespace python {
 void exposeSolverHQuadProg();
 void exposeSolverProxQP();
 void exposeSolverOSQP();
+void exposeSolverDAQP();
 void exposeConstraintLevel();
 void exposeHQPData();
 void exposeHQPOutput();
@@ -39,6 +43,7 @@ inline void exposeSolvers() {
   exposeSolverHQuadProg();
   exposeSolverProxQP();
   exposeSolverOSQP();
+  exposeSolverDAQP();
   exposeConstraintLevel();
   exposeHQPData();
   exposeHQPOutput();

--- a/include/tsid/bindings/python/solvers/solver-HQP-daqp.hpp
+++ b/include/tsid/bindings/python/solvers/solver-HQP-daqp.hpp
@@ -1,0 +1,48 @@
+//
+// Copyright (c) 2026 CNRS
+//
+
+#ifndef __tsid_python_solver_daqp_hpp__
+#define __tsid_python_solver_daqp_hpp__
+
+#include "tsid/bindings/python/fwd.hpp"
+#include "tsid/bindings/python/solvers/HQPData.hpp"
+#include "tsid/solvers/solver-HQP-daqp.hpp"
+
+namespace tsid {
+namespace python {
+namespace bp = boost::python;
+
+template <typename Solver>
+struct SolverDAQPPythonVisitor
+    : public bp::def_visitor<SolverDAQPPythonVisitor<Solver>> {
+  template <class PyClass>
+  void visit(PyClass& cl) const {
+    cl.def(bp::init<const std::string&>(bp::arg("name")))
+        .def("resize", &SolverDAQPPythonVisitor::resize,
+             bp::args("n", "neq", "nin"))
+        .def("solve", &SolverDAQPPythonVisitor::solve, bp::args("HQPData"))
+        .add_property("ObjVal", &Solver::getObjectiveValue,
+                      "Return the objective value.");
+  }
+
+  static void resize(Solver& self, unsigned int n, unsigned int neq,
+                     unsigned int nin) {
+    self.resize(n, neq, nin);
+  }
+
+  static solvers::HQPOutput solve(Solver& self, HQPDatas& data) {
+    return self.solve(data.get());
+  }
+
+  static void expose(const std::string& className) {
+    bp::class_<Solver>(className.c_str(), "DAQP hierarchical QP solver.",
+                       bp::no_init)
+        .def(SolverDAQPPythonVisitor<Solver>());
+  }
+};
+
+}  // namespace python
+}  // namespace tsid
+
+#endif  // __tsid_python_solver_daqp_hpp__

--- a/include/tsid/solvers/fwd.hpp
+++ b/include/tsid/solvers/fwd.hpp
@@ -49,6 +49,10 @@ enum TSID_DLLAPI SolverHQP {
   ,
   SOLVER_HQP_OSQP
 #endif
+#ifdef TSID_WITH_DAQP
+  ,
+  SOLVER_HQP_DAQP
+#endif
 #ifdef QPOASES_FOUND
   ,
   SOLVER_HQP_OASES

--- a/include/tsid/solvers/solver-HQP-daqp.hpp
+++ b/include/tsid/solvers/solver-HQP-daqp.hpp
@@ -1,0 +1,54 @@
+//
+// Copyright (c) 2026 CNRS
+//
+
+#ifndef __invdyn_solvers_hqp_daqp_hpp__
+#define __invdyn_solvers_hqp_daqp_hpp__
+
+#include "tsid/solvers/solver-HQP-base.hpp"
+
+namespace tsid {
+namespace solvers {
+
+/** DAQP-backed solver supporting an arbitrary number of HQP levels. */
+class TSID_DLLAPI SolverHQPDAQP : public SolverHQPBase {
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
+      RowMajorMatrix;
+  typedef math::Vector Vector;
+  typedef math::VectorXi VectorXi;
+
+  explicit SolverHQPDAQP(const std::string& name);
+
+  void resize(unsigned int n, unsigned int neq, unsigned int nin) override;
+  const HQPOutput& solve(const HQPData& problemData) override;
+  void retrieveQPData(const HQPData& problemData,
+                      bool hessianRegularization = true) override;
+  double getObjectiveValue() override;
+  bool setMaximumIterations(unsigned int maxIter) override;
+  bool setMaximumTime(double seconds) override;
+
+  const RowMajorMatrix& constraintMatrix() const { return m_A; }
+  const Vector& lowerBounds() const { return m_lower; }
+  const Vector& upperBounds() const { return m_upper; }
+  const VectorXi& constraintSense() const { return m_sense; }
+  const VectorXi& breakPoints() const { return m_breakPoints; }
+
+ protected:
+  RowMajorMatrix m_A;
+  Vector m_lower;
+  Vector m_upper;
+  VectorXi m_sense;
+  VectorXi m_breakPoints;
+  Vector m_rowScales;
+  double m_objValue;
+  unsigned int m_n;
+  bool m_hasSolution;
+};
+
+}  // namespace solvers
+}  // namespace tsid
+
+#endif  // __invdyn_solvers_hqp_daqp_hpp__

--- a/include/tsid/solvers/solver-HQP-daqp.hpp
+++ b/include/tsid/solvers/solver-HQP-daqp.hpp
@@ -5,6 +5,8 @@
 #ifndef __invdyn_solvers_hqp_daqp_hpp__
 #define __invdyn_solvers_hqp_daqp_hpp__
 
+#include <memory>
+
 #include "tsid/solvers/solver-HQP-base.hpp"
 
 namespace tsid {
@@ -21,6 +23,7 @@ class TSID_DLLAPI SolverHQPDAQP : public SolverHQPBase {
   typedef math::VectorXi VectorXi;
 
   explicit SolverHQPDAQP(const std::string& name);
+  ~SolverHQPDAQP() override;
 
   void resize(unsigned int n, unsigned int neq, unsigned int nin) override;
   const HQPOutput& solve(const HQPData& problemData) override;
@@ -30,6 +33,18 @@ class TSID_DLLAPI SolverHQPDAQP : public SolverHQPBase {
   bool setMaximumIterations(unsigned int maxIter) override;
   bool setMaximumTime(double seconds) override;
 
+  /**
+   * @brief Skip matrix comparisons and reuse the DAQP factorization between
+   * solves. The caller must disable this before changing any constraint or
+   * task matrix, task weight, hierarchy structure, or hard bound. Task
+   * targets may still change. The default is false, which refreshes all
+   * numerical DAQP data on every solve.
+   */
+  void setAssumeMatricesUnchanged(bool unchanged);
+  bool getAssumeMatricesUnchanged() const {
+    return m_assumeMatricesUnchanged;
+  }
+
   const RowMajorMatrix& constraintMatrix() const { return m_A; }
   const Vector& lowerBounds() const { return m_lower; }
   const Vector& upperBounds() const { return m_upper; }
@@ -37,15 +52,31 @@ class TSID_DLLAPI SolverHQPDAQP : public SolverHQPBase {
   const VectorXi& breakPoints() const { return m_breakPoints; }
 
  protected:
+  struct WorkspaceHolder;
+
+  void resetWorkspace();
+  unsigned int maxRowsInLevel() const;
+
   RowMajorMatrix m_A;
   Vector m_lower;
   Vector m_upper;
   VectorXi m_sense;
   VectorXi m_breakPoints;
   Vector m_rowScales;
+  RowMajorMatrix m_H;
+  Vector m_f;
   double m_objValue;
   unsigned int m_n;
+  unsigned int m_totalRows;
+  bool m_useConventionalQP;
   bool m_hasSolution;
+  std::unique_ptr<WorkspaceHolder> m_workspace;
+  unsigned int m_workspaceRows;
+  unsigned int m_workspaceLevels;
+  unsigned int m_workspaceMaxSoftRows;
+  bool m_workspaceUsesConventionalQP;
+  Vector m_daqpLambda;
+  bool m_assumeMatricesUnchanged;
 };
 
 }  // namespace solvers

--- a/include/tsid/solvers/solver-HQP-daqp.hpp
+++ b/include/tsid/solvers/solver-HQP-daqp.hpp
@@ -41,9 +41,7 @@ class TSID_DLLAPI SolverHQPDAQP : public SolverHQPBase {
    * numerical DAQP data on every solve.
    */
   void setAssumeMatricesUnchanged(bool unchanged);
-  bool getAssumeMatricesUnchanged() const {
-    return m_assumeMatricesUnchanged;
-  }
+  bool getAssumeMatricesUnchanged() const { return m_assumeMatricesUnchanged; }
 
   const RowMajorMatrix& constraintMatrix() const { return m_A; }
   const Vector& lowerBounds() const { return m_lower; }

--- a/src/solvers/solver-HQP-daqp.cpp
+++ b/src/solvers/solver-HQP-daqp.cpp
@@ -176,8 +176,8 @@ void SolverHQPDAQP::retrieveQPData(const HQPData& problemData, bool) {
   }
 
   if (m_useConventionalQP) {
-    const bool rebuildH = !m_assumeMatricesUnchanged || m_H.rows() != n ||
-                          m_H.cols() != n;
+    const bool rebuildH =
+        !m_assumeMatricesUnchanged || m_H.rows() != n || m_H.cols() != n;
     if (rebuildH) m_H.setZero(n, n);
     m_f.setZero(n);
     for (const auto& item : problemData[1]) {
@@ -185,10 +185,10 @@ void SolverHQPDAQP::retrieveQPData(const HQPData& problemData, bool) {
       const auto& constraint = item.second;
       const double weight = item.first;
       if (rebuildH)
-        m_H.noalias() += weight * constraint->matrix().transpose() *
-                          constraint->matrix();
-      m_f.noalias() -= weight * constraint->matrix().transpose() *
-                        constraint->vector();
+        m_H.noalias() +=
+            weight * constraint->matrix().transpose() * constraint->matrix();
+      m_f.noalias() -=
+          weight * constraint->matrix().transpose() * constraint->vector();
     }
   } else {
     m_H.resize(0, 0);
@@ -266,8 +266,8 @@ const HQPOutput& SolverHQPDAQP::solve(const HQPData& problemData) {
         updateMask |= DAQP_UPDATE_d;
       }
     } else if (m_useConventionalQP) {
-      updateMask |= DAQP_UPDATE_Rinv | DAQP_UPDATE_M | DAQP_UPDATE_v |
-                    DAQP_UPDATE_d;
+      updateMask |=
+          DAQP_UPDATE_Rinv | DAQP_UPDATE_M | DAQP_UPDATE_v | DAQP_UPDATE_d;
     } else {
       updateMask |= DAQP_UPDATE_M | DAQP_UPDATE_d | DAQP_UPDATE_hierarchy;
       normalizationChanged = true;

--- a/src/solvers/solver-HQP-daqp.cpp
+++ b/src/solvers/solver-HQP-daqp.cpp
@@ -6,16 +6,24 @@
 
 #if __has_include(<daqp/api.h>)
 #include <daqp/api.h>
+#include <daqp/utils.h>
 #else
 #include <api.h>
+#include <utils.h>
 #endif
 
+#include <algorithm>
 #include <cmath>
 
 #include <pinocchio/macros.hpp>
 
 namespace tsid {
 namespace solvers {
+
+struct SolverHQPDAQP::WorkspaceHolder {
+  DAQPWorkspace workspace = {};
+  DAQPSettings settings = {};
+};
 
 namespace {
 
@@ -27,13 +35,64 @@ unsigned int constraintRows(const ConstraintLevel& level) {
   return rows;
 }
 
+bool supportsConventionalQP(const HQPData& problemData) {
+  if (problemData.size() != 2) return false;
+  for (const auto& item : problemData[1]) {
+    if (item.first != 0. && !item.second->isEquality()) return false;
+  }
+  return true;
+}
+
 }  // namespace
 
 SolverHQPDAQP::SolverHQPDAQP(const std::string& name)
-    : SolverHQPBase(name), m_objValue(0.), m_n(0), m_hasSolution(false) {}
+    : SolverHQPBase(name),
+      m_objValue(0.),
+      m_n(0),
+      m_totalRows(0),
+      m_useConventionalQP(false),
+      m_hasSolution(false),
+      m_workspaceRows(0),
+      m_workspaceLevels(0),
+      m_workspaceMaxSoftRows(0),
+      m_workspaceUsesConventionalQP(false),
+      m_assumeMatricesUnchanged(false) {}
+
+SolverHQPDAQP::~SolverHQPDAQP() { resetWorkspace(); }
+
+void SolverHQPDAQP::resetWorkspace() {
+  if (m_workspace) {
+    m_workspace->workspace.settings = nullptr;
+    free_daqp_workspace(&m_workspace->workspace);
+    free_daqp_ldp(&m_workspace->workspace);
+    m_workspace.reset();
+  }
+  m_workspaceRows = 0;
+  m_workspaceLevels = 0;
+  m_workspaceMaxSoftRows = 0;
+  m_workspaceUsesConventionalQP = false;
+}
+
+void SolverHQPDAQP::setAssumeMatricesUnchanged(bool unchanged) {
+  m_assumeMatricesUnchanged = unchanged;
+}
+
+unsigned int SolverHQPDAQP::maxRowsInLevel() const {
+  unsigned int maxRows = 0;
+  int previous = 0;
+  for (Eigen::Index i = 0; i < m_breakPoints.size(); ++i) {
+    const int rows = m_breakPoints[i] - previous;
+    if (rows > 0) maxRows = std::max(maxRows, static_cast<unsigned int>(rows));
+    previous = m_breakPoints[i];
+  }
+  return maxRows;
+}
 
 void SolverHQPDAQP::resize(unsigned int n, unsigned int, unsigned int) {
-  if (n != m_n) m_hasSolution = false;
+  if (n != m_n) {
+    m_hasSolution = false;
+    resetWorkspace();
+  }
   m_n = n;
   m_output.x.resize(n);
 }
@@ -60,16 +119,23 @@ void SolverHQPDAQP::retrieveQPData(const HQPData& problemData, bool) {
   PINOCCHIO_CHECK_INPUT_ARGUMENT(n > 0,
                                  "Cannot infer the number of HQP variables");
 
-  resize(n, 0, rows);
-  m_A.resize(rows, n);
-  m_lower.resize(rows);
-  m_upper.resize(rows);
-  m_sense.setZero(rows);
-  m_rowScales.setZero(rows);
-  m_breakPoints.resize(problemData.size());
+  m_useConventionalQP = supportsConventionalQP(problemData);
+  m_totalRows = rows;
+  const unsigned int activeRows =
+      m_useConventionalQP ? constraintRows(problemData[0]) : rows;
+
+  resize(n, 0, activeRows);
+  m_A.resize(activeRows, n);
+  m_lower.resize(activeRows);
+  m_upper.resize(activeRows);
+  m_sense.setZero(activeRows);
+  m_rowScales.setZero(activeRows);
+  m_breakPoints.resize(m_useConventionalQP ? 1 : problemData.size());
 
   unsigned int row = 0;
-  for (std::size_t levelIndex = 0; levelIndex < problemData.size();
+  const std::size_t constraintLevels =
+      m_useConventionalQP ? 1 : problemData.size();
+  for (std::size_t levelIndex = 0; levelIndex < constraintLevels;
        ++levelIndex) {
     for (const auto& item : problemData[levelIndex]) {
       const double weight = item.first;
@@ -101,76 +167,143 @@ void SolverHQPDAQP::retrieveQPData(const HQPData& problemData, bool) {
     m_breakPoints[levelIndex] = static_cast<int>(row);
   }
 
-  if (row != rows) {
+  if (row != activeRows) {
     m_A.conservativeResize(row, n);
     m_lower.conservativeResize(row);
     m_upper.conservativeResize(row);
     m_sense.conservativeResize(row);
     m_rowScales.conservativeResize(row);
   }
-  if (m_output.lambda.size() != static_cast<Eigen::Index>(row)) {
+
+  if (m_useConventionalQP) {
+    const bool rebuildH = !m_assumeMatricesUnchanged || m_H.rows() != n ||
+                          m_H.cols() != n;
+    if (rebuildH) m_H.setZero(n, n);
+    m_f.setZero(n);
+    for (const auto& item : problemData[1]) {
+      if (item.first == 0.) continue;
+      const auto& constraint = item.second;
+      const double weight = item.first;
+      if (rebuildH)
+        m_H.noalias() += weight * constraint->matrix().transpose() *
+                          constraint->matrix();
+      m_f.noalias() -= weight * constraint->matrix().transpose() *
+                        constraint->vector();
+    }
+  } else {
+    m_H.resize(0, 0);
+    m_f.resize(0);
+  }
+
+  if (m_output.lambda.size() != static_cast<Eigen::Index>(m_totalRows) ||
+      m_daqpLambda.size() != static_cast<Eigen::Index>(row)) {
     m_hasSolution = false;
   }
-  m_output.lambda.resize(row);
-  m_output.activeSet.resize(row);
+  m_output.lambda.resize(m_totalRows);
+  m_output.activeSet.resize(m_totalRows);
+  m_daqpLambda.resize(row);
+
+  if (m_workspace &&
+      (m_workspaceRows != row ||
+       m_workspaceLevels != static_cast<unsigned int>(m_breakPoints.size()) ||
+       m_workspaceMaxSoftRows < maxRowsInLevel() ||
+       m_workspaceUsesConventionalQP != m_useConventionalQP)) {
+    m_hasSolution = false;
+    resetWorkspace();
+  }
 }
 
 const HQPOutput& SolverHQPDAQP::solve(const HQPData& problemData) {
   retrieveQPData(problemData, false);
 
-  DAQPSettings settings;
-  daqp_default_settings(&settings);
-  settings.iter_limit = static_cast<int>(m_maxIter);
-  settings.time_limit = m_maxTime;
-
   DAQPProblem problem = {};
   problem.n = static_cast<int>(m_n);
   problem.m = static_cast<int>(m_lower.size());
   problem.ms = 0;
+  problem.H = m_useConventionalQP ? m_H.data() : nullptr;
+  problem.f = m_useConventionalQP ? m_f.data() : nullptr;
   problem.A = m_A.size() == 0 ? nullptr : m_A.data();
   problem.bupper = m_upper.size() == 0 ? nullptr : m_upper.data();
   problem.blower = m_lower.size() == 0 ? nullptr : m_lower.data();
   problem.sense = m_sense.size() == 0 ? nullptr : m_sense.data();
   problem.break_points =
       m_breakPoints.size() == 0 ? nullptr : m_breakPoints.data();
-  problem.nh = static_cast<int>(m_breakPoints.size());
+  problem.nh = m_useConventionalQP ? 1 : static_cast<int>(m_breakPoints.size());
 
   if (m_useWarmStart && m_hasSolution) {
     daqp_primal_init_active(&problem, m_output.x.data());
-    daqp_dual_init_active(&problem, m_output.lambda.data());
+    daqp_dual_init_active(&problem, m_daqpLambda.data());
   }
-  m_output.lambda.setZero();
+  m_daqpLambda.setZero();
   DAQPResult result = {};
   result.x = m_output.x.data();
-  result.lam = m_output.lambda.size() == 0 ? nullptr : m_output.lambda.data();
+  result.lam = m_daqpLambda.size() == 0 ? nullptr : m_daqpLambda.data();
 
-  DAQPWorkspace workspace = {};
-  workspace.settings = &settings;
-  result.exitflag =
-      setup_daqp_main(&problem, &workspace, &result.setup_time, 1);
-  if (result.exitflag >= 0) {
-    // DAQP normalizes constraint rows during setup. Undo that normalization
-    // for soft task rows, then apply TSID's sqrt(weight) scaling so the
-    // least-squares metric is preserved.
-    for (int i = 0; i < problem.m; ++i) {
-      const double desiredScale = m_rowScales[i];
-      if (desiredScale == 0.) continue;
-      const double scale = desiredScale / workspace.scaling[i];
-      for (int j = 0; j < problem.n; ++j) {
-        workspace.M[problem.n * i + j] *= scale;
+  bool normalizationChanged = false;
+
+  if (!m_workspace) {
+    m_workspace = std::make_unique<WorkspaceHolder>();
+    daqp_default_settings(&m_workspace->settings);
+    m_workspace->settings.iter_limit = static_cast<int>(m_maxIter);
+    m_workspace->settings.time_limit = m_maxTime;
+    m_workspace->workspace.settings = &m_workspace->settings;
+    m_workspaceRows = static_cast<unsigned int>(problem.m);
+    m_workspaceLevels = static_cast<unsigned int>(problem.nh);
+    m_workspaceMaxSoftRows = maxRowsInLevel();
+    m_workspaceUsesConventionalQP = m_useConventionalQP;
+    result.exitflag = setup_daqp_main(&problem, &m_workspace->workspace,
+                                      &result.setup_time, 1);
+    normalizationChanged = !m_useConventionalQP;
+  } else {
+    m_workspace->settings.iter_limit = static_cast<int>(m_maxIter);
+    m_workspace->settings.time_limit = m_maxTime;
+    int updateMask = DAQP_UPDATE_sense;
+    if (m_assumeMatricesUnchanged) {
+      if (m_useConventionalQP) {
+        updateMask |= DAQP_UPDATE_v | DAQP_UPDATE_d;
+      } else {
+        updateMask |= DAQP_UPDATE_hierarchy;
+        updateMask |= DAQP_UPDATE_d;
       }
-      workspace.dupper[i] *= scale;
-      workspace.dlower[i] *= scale;
-      workspace.scaling[i] *= scale;
+    } else if (m_useConventionalQP) {
+      updateMask |= DAQP_UPDATE_Rinv | DAQP_UPDATE_M | DAQP_UPDATE_v |
+                    DAQP_UPDATE_d;
+    } else {
+      updateMask |= DAQP_UPDATE_M | DAQP_UPDATE_d | DAQP_UPDATE_hierarchy;
+      normalizationChanged = true;
     }
-    daqp_solve(&result, &workspace);
+    result.exitflag =
+        daqp_update_ldp(updateMask, &m_workspace->workspace, &problem);
   }
-  workspace.settings = nullptr;
-  free_daqp_workspace(&workspace);
-  free_daqp_ldp(&workspace);
+
+  const double dualTolerance = m_workspace->settings.dual_tol;
+  if (result.exitflag >= 0) {
+    if (!m_useConventionalQP && normalizationChanged) {
+      // DAQP normalizes constraint rows during setup. Undo that normalization
+      // for soft task rows, then apply TSID's sqrt(weight) scaling so the
+      // least-squares metric is preserved. Retain the adjusted rows while the
+      // caller promises that matrices are unchanged.
+      for (int i = 0; i < problem.m; ++i) {
+        const double desiredScale = m_rowScales[i];
+        if (desiredScale == 0.) continue;
+        const double scale = desiredScale / m_workspace->workspace.scaling[i];
+        for (int j = 0; j < problem.n; ++j) {
+          m_workspace->workspace.M[problem.n * i + j] *= scale;
+        }
+        m_workspace->workspace.dupper[i] *= scale;
+        m_workspace->workspace.dlower[i] *= scale;
+        m_workspace->workspace.scaling[i] *= scale;
+      }
+    }
+    daqp_solve(&result, &m_workspace->workspace);
+  } else {
+    resetWorkspace();
+  }
 
   m_objValue = result.fval;
   m_output.iterations = result.iter;
+  m_output.lambda.setZero();
+  m_output.lambda.head(problem.m) = m_daqpLambda;
   if (result.exitflag > 0) {
     m_output.status = HQP_STATUS_OPTIMAL;
   } else if (result.exitflag == DAQP_EXIT_INFEASIBLE) {
@@ -187,7 +320,7 @@ const HQPOutput& SolverHQPDAQP::solve(const HQPData& problemData) {
 
   int activeCount = 0;
   for (Eigen::Index i = 0; i < m_output.lambda.size(); ++i) {
-    if (std::abs(m_output.lambda[i]) > settings.dual_tol) {
+    if (std::abs(m_output.lambda[i]) > dualTolerance) {
       m_output.activeSet[activeCount++] = static_cast<int>(i);
     }
   }

--- a/src/solvers/solver-HQP-daqp.cpp
+++ b/src/solvers/solver-HQP-daqp.cpp
@@ -1,0 +1,209 @@
+//
+// Copyright (c) 2026 CNRS
+//
+
+#include "tsid/solvers/solver-HQP-daqp.hpp"
+
+#if __has_include(<daqp/api.h>)
+#include <daqp/api.h>
+#else
+#include <api.h>
+#endif
+
+#include <cmath>
+
+#include <pinocchio/macros.hpp>
+
+namespace tsid {
+namespace solvers {
+
+namespace {
+
+unsigned int constraintRows(const ConstraintLevel& level) {
+  unsigned int rows = 0;
+  for (const auto& item : level) {
+    if (item.first != 0.) rows += item.second->rows();
+  }
+  return rows;
+}
+
+}  // namespace
+
+SolverHQPDAQP::SolverHQPDAQP(const std::string& name)
+    : SolverHQPBase(name), m_objValue(0.), m_n(0), m_hasSolution(false) {}
+
+void SolverHQPDAQP::resize(unsigned int n, unsigned int, unsigned int) {
+  if (n != m_n) m_hasSolution = false;
+  m_n = n;
+  m_output.x.resize(n);
+}
+
+void SolverHQPDAQP::retrieveQPData(const HQPData& problemData, bool) {
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(!problemData.empty(),
+                                 "HQP data must contain at least one level");
+
+  unsigned int n = 0;
+  unsigned int rows = 0;
+  for (const ConstraintLevel& level : problemData) {
+    rows += constraintRows(level);
+    for (const auto& item : level) {
+      if (item.second->rows() == 0) continue;
+      if (n == 0) n = item.second->cols();
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(
+          item.second->cols() == n,
+          "All HQP constraints must have the same number of columns");
+      PINOCCHIO_CHECK_INPUT_ARGUMENT(
+          item.first >= 0., "HQP constraint weights must be nonnegative");
+    }
+  }
+  if (n == 0) n = m_n;
+  PINOCCHIO_CHECK_INPUT_ARGUMENT(n > 0,
+                                 "Cannot infer the number of HQP variables");
+
+  resize(n, 0, rows);
+  m_A.resize(rows, n);
+  m_lower.resize(rows);
+  m_upper.resize(rows);
+  m_sense.setZero(rows);
+  m_rowScales.setZero(rows);
+  m_breakPoints.resize(problemData.size());
+
+  unsigned int row = 0;
+  for (std::size_t levelIndex = 0; levelIndex < problemData.size();
+       ++levelIndex) {
+    for (const auto& item : problemData[levelIndex]) {
+      const double weight = item.first;
+      const std::shared_ptr<math::ConstraintBase>& constraint = item.second;
+      if (weight == 0.) continue;
+
+      const unsigned int count = constraint->rows();
+      const double scale = levelIndex == 0 ? 0. : std::sqrt(weight);
+      if (constraint->isBound()) {
+        PINOCCHIO_CHECK_INPUT_ARGUMENT(
+            count == n,
+            "A bound constraint must have one row per HQP variable");
+        m_A.middleRows(row, count).setIdentity();
+      } else {
+        m_A.middleRows(row, count) = constraint->matrix();
+      }
+
+      if (constraint->isEquality()) {
+        m_lower.segment(row, count) = constraint->vector();
+        m_upper.segment(row, count) = constraint->vector();
+        m_sense.segment(row, count).setConstant(DAQP_ACTIVE + DAQP_IMMUTABLE);
+      } else {
+        m_lower.segment(row, count) = constraint->lowerBound();
+        m_upper.segment(row, count) = constraint->upperBound();
+      }
+      m_rowScales.segment(row, count).setConstant(scale);
+      row += count;
+    }
+    m_breakPoints[levelIndex] = static_cast<int>(row);
+  }
+
+  if (row != rows) {
+    m_A.conservativeResize(row, n);
+    m_lower.conservativeResize(row);
+    m_upper.conservativeResize(row);
+    m_sense.conservativeResize(row);
+    m_rowScales.conservativeResize(row);
+  }
+  if (m_output.lambda.size() != static_cast<Eigen::Index>(row)) {
+    m_hasSolution = false;
+  }
+  m_output.lambda.resize(row);
+  m_output.activeSet.resize(row);
+}
+
+const HQPOutput& SolverHQPDAQP::solve(const HQPData& problemData) {
+  retrieveQPData(problemData, false);
+
+  DAQPSettings settings;
+  daqp_default_settings(&settings);
+  settings.iter_limit = static_cast<int>(m_maxIter);
+  settings.time_limit = m_maxTime;
+
+  DAQPProblem problem = {};
+  problem.n = static_cast<int>(m_n);
+  problem.m = static_cast<int>(m_lower.size());
+  problem.ms = 0;
+  problem.A = m_A.size() == 0 ? nullptr : m_A.data();
+  problem.bupper = m_upper.size() == 0 ? nullptr : m_upper.data();
+  problem.blower = m_lower.size() == 0 ? nullptr : m_lower.data();
+  problem.sense = m_sense.size() == 0 ? nullptr : m_sense.data();
+  problem.break_points =
+      m_breakPoints.size() == 0 ? nullptr : m_breakPoints.data();
+  problem.nh = static_cast<int>(m_breakPoints.size());
+
+  if (m_useWarmStart && m_hasSolution) {
+    daqp_primal_init_active(&problem, m_output.x.data());
+    daqp_dual_init_active(&problem, m_output.lambda.data());
+  }
+  m_output.lambda.setZero();
+  DAQPResult result = {};
+  result.x = m_output.x.data();
+  result.lam = m_output.lambda.size() == 0 ? nullptr : m_output.lambda.data();
+
+  DAQPWorkspace workspace = {};
+  workspace.settings = &settings;
+  result.exitflag =
+      setup_daqp_main(&problem, &workspace, &result.setup_time, 1);
+  if (result.exitflag >= 0) {
+    // DAQP normalizes constraint rows during setup. Undo that normalization
+    // for soft task rows, then apply TSID's sqrt(weight) scaling so the
+    // least-squares metric is preserved.
+    for (int i = 0; i < problem.m; ++i) {
+      const double desiredScale = m_rowScales[i];
+      if (desiredScale == 0.) continue;
+      const double scale = desiredScale / workspace.scaling[i];
+      for (int j = 0; j < problem.n; ++j) {
+        workspace.M[problem.n * i + j] *= scale;
+      }
+      workspace.dupper[i] *= scale;
+      workspace.dlower[i] *= scale;
+      workspace.scaling[i] *= scale;
+    }
+    daqp_solve(&result, &workspace);
+  }
+  workspace.settings = nullptr;
+  free_daqp_workspace(&workspace);
+  free_daqp_ldp(&workspace);
+
+  m_objValue = result.fval;
+  m_output.iterations = result.iter;
+  if (result.exitflag > 0) {
+    m_output.status = HQP_STATUS_OPTIMAL;
+  } else if (result.exitflag == DAQP_EXIT_INFEASIBLE) {
+    m_output.status = HQP_STATUS_INFEASIBLE;
+  } else if (result.exitflag == DAQP_EXIT_UNBOUNDED) {
+    m_output.status = HQP_STATUS_UNBOUNDED;
+  } else if (result.exitflag == DAQP_EXIT_ITERLIMIT ||
+             result.exitflag == DAQP_EXIT_TIMELIMIT) {
+    m_output.status = HQP_STATUS_MAX_ITER_REACHED;
+  } else {
+    m_output.status = HQP_STATUS_ERROR;
+  }
+  m_hasSolution = m_output.status == HQP_STATUS_OPTIMAL;
+
+  int activeCount = 0;
+  for (Eigen::Index i = 0; i < m_output.lambda.size(); ++i) {
+    if (std::abs(m_output.lambda[i]) > settings.dual_tol) {
+      m_output.activeSet[activeCount++] = static_cast<int>(i);
+    }
+  }
+  m_output.activeSet.conservativeResize(activeCount);
+  return m_output;
+}
+
+double SolverHQPDAQP::getObjectiveValue() { return m_objValue; }
+
+bool SolverHQPDAQP::setMaximumIterations(unsigned int maxIter) {
+  return SolverHQPBase::setMaximumIterations(maxIter);
+}
+
+bool SolverHQPDAQP::setMaximumTime(double seconds) {
+  return SolverHQPBase::setMaximumTime(seconds);
+}
+
+}  // namespace solvers
+}  // namespace tsid

--- a/src/solvers/solver-HQP-daqp.cpp
+++ b/src/solvers/solver-HQP-daqp.cpp
@@ -296,6 +296,10 @@ const HQPOutput& SolverHQPDAQP::solve(const HQPData& problemData) {
       }
     }
     daqp_solve(&result, &m_workspace->workspace);
+    // DAQP's public hierarchical result contains soft-level duals. TSID
+    // needs the final active-set signs to warm-start the next hierarchy.
+    if (!m_useConventionalQP)
+      daqp_extract_active_duals(&result, &m_workspace->workspace);
   } else {
     resetWorkspace();
   }

--- a/src/solvers/solver-HQP-factory.cpp
+++ b/src/solvers/solver-HQP-factory.cpp
@@ -18,6 +18,10 @@
 #include <tsid/solvers/solver-osqp.hpp>
 #endif
 
+#ifdef TSID_WITH_DAQP
+#include <tsid/solvers/solver-HQP-daqp.hpp>
+#endif
+
 #ifdef QPOASES_FOUND
 #include <tsid/solvers/solver-HQP-qpoases.hh>
 #endif
@@ -42,6 +46,10 @@ SolverHQPBase* SolverHQPFactory::createNewSolver(const SolverHQP solverType,
 
 #ifdef TSID_WITH_OSQP
   if (solverType == SOLVER_HQP_OSQP) return new SolverOSQP(name);
+#endif
+
+#ifdef TSID_WITH_DAQP
+  if (solverType == SOLVER_HQP_DAQP) return new SolverHQPDAQP(name);
 #endif
 
 #ifdef QPOASES_FOUND

--- a/tests/hqp_solvers.cpp
+++ b/tests/hqp_solvers.cpp
@@ -20,6 +20,9 @@
 #ifdef TSID_QPMAD_FOUND
 #include <tsid/solvers/solver-HQP-qpmad.hpp>
 #endif
+#ifdef TSID_WITH_DAQP
+#include <tsid/solvers/solver-HQP-daqp.hpp>
+#endif
 
 #include <tsid/math/utils.hpp>
 #include <tsid/math/constraint-equality.hpp>
@@ -33,6 +36,84 @@
 #define REQUIRE_FINITE(A) BOOST_REQUIRE_MESSAGE(isFinite(A), #A << ": " << A)
 
 BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
+
+#ifdef TSID_WITH_DAQP
+BOOST_AUTO_TEST_CASE(test_daqp_multilevel_hierarchy) {
+  using namespace tsid;
+  using namespace math;
+  using namespace solvers;
+
+  std::unique_ptr<SolverHQPBase> solver(
+      SolverHQPFactory::createNewSolver(SOLVER_HQP_DAQP, "daqp"));
+  HQPData data(4);
+
+  const Vector lower = Vector::Constant(2, -10.);
+  const Vector upper = Vector::Constant(2, 10.);
+  auto bounds = std::make_shared<ConstraintBound>("bounds", lower, upper);
+  data[0].push_back(
+      solvers::make_pair<double, std::shared_ptr<ConstraintBase>>(1., bounds));
+
+  Matrix selectX(1, 2);
+  selectX << 1., 0.;
+  auto xIsOne = std::make_shared<ConstraintEquality>("x-is-one", selectX,
+                                                     Vector::Constant(1, 1.));
+  data[1].push_back(
+      solvers::make_pair<double, std::shared_ptr<ConstraintBase>>(1., xIsOne));
+
+  Matrix identity = Matrix::Identity(2, 2);
+  Vector secondTarget(2);
+  secondTarget << 2., 3.;
+  auto secondLevel = std::make_shared<ConstraintEquality>(
+      "second-level", identity, secondTarget);
+  data[2].push_back(solvers::make_pair<double, std::shared_ptr<ConstraintBase>>(
+      1., secondLevel));
+
+  Matrix selectY(1, 2);
+  selectY << 0., 1.;
+  auto yIsMinusFour = std::make_shared<ConstraintEquality>(
+      "y-is-minus-four", selectY, Vector::Constant(1, -4.));
+  data[3].push_back(solvers::make_pair<double, std::shared_ptr<ConstraintBase>>(
+      1., yIsMinusFour));
+
+  const HQPOutput& output = solver->solve(data);
+  BOOST_REQUIRE_EQUAL(output.status, HQP_STATUS_OPTIMAL);
+  Vector expected(2);
+  expected << 1., 3.;
+  BOOST_CHECK_MESSAGE(
+      output.x.isApprox(expected, 1e-5),
+      "Unexpected hierarchical solution: " << output.x.transpose());
+
+  const HQPOutput& warmOutput = solver->solve(data);
+  BOOST_REQUIRE_EQUAL(warmOutput.status, HQP_STATUS_OPTIMAL);
+  BOOST_CHECK(warmOutput.x.isApprox(expected, 1e-5));
+}
+
+BOOST_AUTO_TEST_CASE(test_daqp_weighted_level) {
+  using namespace tsid;
+  using namespace math;
+  using namespace solvers;
+
+  SolverHQPDAQP solver("daqp");
+  HQPData data(2);
+  Matrix A = Matrix::Ones(1, 1);
+  auto zero = std::make_shared<ConstraintEquality>(
+      "zero", 2. * A, Vector::Zero(1));
+  auto two =
+      std::make_shared<ConstraintEquality>("two", A, Vector::Constant(1, 2.));
+  auto hardRange = std::make_shared<ConstraintInequality>(
+      "hard-range", A, Vector::Zero(1), Vector::Constant(1, 2.));
+  data[0].push_back(solvers::make_pair<double, std::shared_ptr<ConstraintBase>>(
+      1., hardRange));
+  data[1].push_back(
+      solvers::make_pair<double, std::shared_ptr<ConstraintBase>>(1., zero));
+  data[1].push_back(
+      solvers::make_pair<double, std::shared_ptr<ConstraintBase>>(3., two));
+
+  const HQPOutput& output = solver.solve(data);
+  BOOST_REQUIRE_EQUAL(output.status, HQP_STATUS_OPTIMAL);
+  BOOST_CHECK_SMALL(output.x[0] - 6. / 7., 1e-5);
+}
+#endif
 
 // BOOST_AUTO_TEST_CASE ( test_eiquadprog_unconstrained)
 //{

--- a/tests/hqp_solvers.cpp
+++ b/tests/hqp_solvers.cpp
@@ -82,10 +82,19 @@ BOOST_AUTO_TEST_CASE(test_daqp_multilevel_hierarchy) {
   BOOST_CHECK_MESSAGE(
       output.x.isApprox(expected, 1e-5),
       "Unexpected hierarchical solution: " << output.x.transpose());
+  BOOST_CHECK_GT(output.lambda.cwiseAbs().maxCoeff(), 0.);
 
   const HQPOutput& warmOutput = solver->solve(data);
   BOOST_REQUIRE_EQUAL(warmOutput.status, HQP_STATUS_OPTIMAL);
   BOOST_CHECK(warmOutput.x.isApprox(expected, 1e-5));
+
+  static_cast<SolverHQPDAQP*>(solver.get())
+      ->setAssumeMatricesUnchanged(true);
+  secondLevel->vector()[1] = 4.;
+  const HQPOutput& updatedOutput = solver->solve(data);
+  BOOST_REQUIRE_EQUAL(updatedOutput.status, HQP_STATUS_OPTIMAL);
+  expected[1] = 4.;
+  BOOST_CHECK(updatedOutput.x.isApprox(expected, 1e-5));
 }
 
 BOOST_AUTO_TEST_CASE(test_daqp_weighted_level) {
@@ -112,6 +121,18 @@ BOOST_AUTO_TEST_CASE(test_daqp_weighted_level) {
   const HQPOutput& output = solver.solve(data);
   BOOST_REQUIRE_EQUAL(output.status, HQP_STATUS_OPTIMAL);
   BOOST_CHECK_SMALL(output.x[0] - 6. / 7., 1e-5);
+
+  solver.setAssumeMatricesUnchanged(true);
+  two->vector()[0] = 1.;
+  const HQPOutput& updatedOutput = solver.solve(data);
+  BOOST_REQUIRE_EQUAL(updatedOutput.status, HQP_STATUS_OPTIMAL);
+  BOOST_CHECK_SMALL(updatedOutput.x[0] - 3. / 7., 1e-5);
+
+  solver.setAssumeMatricesUnchanged(false);
+  hardRange->lowerBound()[0] = .5;
+  const HQPOutput& boundedOutput = solver.solve(data);
+  BOOST_REQUIRE_EQUAL(boundedOutput.status, HQP_STATUS_OPTIMAL);
+  BOOST_CHECK_SMALL(boundedOutput.x[0] - .5, 1e-5);
 }
 #endif
 
@@ -251,6 +272,10 @@ BOOST_AUTO_TEST_CASE(test_daqp_weighted_level) {
 #define PROFILE_EIQUADPROG "Eiquadprog"
 #define PROFILE_EIQUADPROG_RT "Eiquadprog Real Time"
 #define PROFILE_EIQUADPROG_FAST "Eiquadprog Fast"
+#define PROFILE_DAQP "DAQP"
+#define PROFILE_DAQP_COLD "DAQP cold"
+#define PROFILE_DAQP_REUSE "DAQP reuse"
+#define PROFILE_DAQP_REUSE_COLD "DAQP reuse cold"
 #define PROFILE_PROXQP "Proxqp"
 #define PROFILE_OSQP "OSQP"
 #define PROFILE_QPMAD "QPMAD"
@@ -301,6 +326,26 @@ BOOST_AUTO_TEST_CASE(test_eiquadprog_classic_vs_rt_vs_fast_vs_proxqp) {
   SolverHQPBase* solver =
       SolverHQPFactory::createNewSolver(SOLVER_HQP_EIQUADPROG, "eiquadprog");
   solver->resize(n, neq, nin);
+
+#ifdef TSID_WITH_DAQP
+  SolverHQPBase* solver_daqp =
+      SolverHQPFactory::createNewSolver(SOLVER_HQP_DAQP, "daqp");
+  solver_daqp->resize(n, neq, nin);
+
+  SolverHQPBase* solver_daqp_cold =
+      SolverHQPFactory::createNewSolver(SOLVER_HQP_DAQP, "daqp_cold");
+  solver_daqp_cold->setUseWarmStart(false);
+  solver_daqp_cold->resize(n, neq, nin);
+
+  SolverHQPDAQP* solver_daqp_reuse = static_cast<SolverHQPDAQP*>(
+      SolverHQPFactory::createNewSolver(SOLVER_HQP_DAQP, "daqp_reuse"));
+  solver_daqp_reuse->resize(n, neq, nin);
+
+  SolverHQPDAQP* solver_daqp_reuse_cold = static_cast<SolverHQPDAQP*>(
+      SolverHQPFactory::createNewSolver(SOLVER_HQP_DAQP, "daqp_reuse_cold"));
+  solver_daqp_reuse_cold->setUseWarmStart(false);
+  solver_daqp_reuse_cold->resize(n, neq, nin);
+#endif
 
 #ifdef TSID_WITH_PROXSUITE
   SolverHQPBase* solver_proxqp =
@@ -375,6 +420,10 @@ BOOST_AUTO_TEST_CASE(test_eiquadprog_classic_vs_rt_vs_fast_vs_proxqp) {
       cost->matrix() += hessianPerturbations[i];
       cost->vector() += gradientPerturbations[i];
     }
+#ifdef TSID_WITH_DAQP
+    solver_daqp_reuse->setAssumeMatricesUnchanged(false);
+    solver_daqp_reuse_cold->setAssumeMatricesUnchanged(false);
+#endif
     // First run to init outputs
     getProfiler().start(PROFILE_EIQUADPROG_FAST);
     const HQPOutput& output_fast = solver_fast->solve(HQPData);
@@ -387,6 +436,25 @@ BOOST_AUTO_TEST_CASE(test_eiquadprog_classic_vs_rt_vs_fast_vs_proxqp) {
     getProfiler().start(PROFILE_EIQUADPROG);
     const HQPOutput& output = solver->solve(HQPData);
     getProfiler().stop(PROFILE_EIQUADPROG);
+
+#ifdef TSID_WITH_DAQP
+    getProfiler().start(PROFILE_DAQP);
+    const HQPOutput& output_daqp = solver_daqp->solve(HQPData);
+    getProfiler().stop(PROFILE_DAQP);
+
+    getProfiler().start(PROFILE_DAQP_COLD);
+    const HQPOutput& output_daqp_cold = solver_daqp_cold->solve(HQPData);
+    getProfiler().stop(PROFILE_DAQP_COLD);
+
+    getProfiler().start(PROFILE_DAQP_REUSE);
+    const HQPOutput& output_daqp_reuse = solver_daqp_reuse->solve(HQPData);
+    getProfiler().stop(PROFILE_DAQP_REUSE);
+
+    getProfiler().start(PROFILE_DAQP_REUSE_COLD);
+    const HQPOutput& output_daqp_reuse_cold =
+        solver_daqp_reuse_cold->solve(HQPData);
+    getProfiler().stop(PROFILE_DAQP_REUSE_COLD);
+#endif
 
 #ifdef TSID_WITH_PROXSUITE
     getProfiler().start(PROFILE_PROXQP);
@@ -405,6 +473,10 @@ BOOST_AUTO_TEST_CASE(test_eiquadprog_classic_vs_rt_vs_fast_vs_proxqp) {
     const HQPOutput& output_qpmad = solver_qpmad->solve(HQPData);
     getProfiler().stop(PROFILE_QPMAD);
 #endif
+#ifdef TSID_WITH_DAQP
+    solver_daqp_reuse->setAssumeMatricesUnchanged(true);
+    solver_daqp_reuse_cold->setAssumeMatricesUnchanged(true);
+#endif
     // Loop to smooth variance for each problem
     for (unsigned int j = 0; j < nsmooth; j++) {
       getProfiler().start(PROFILE_EIQUADPROG_FAST);
@@ -418,6 +490,24 @@ BOOST_AUTO_TEST_CASE(test_eiquadprog_classic_vs_rt_vs_fast_vs_proxqp) {
       getProfiler().start(PROFILE_EIQUADPROG);
       (void)solver->solve(HQPData);
       getProfiler().stop(PROFILE_EIQUADPROG);
+
+#ifdef TSID_WITH_DAQP
+      getProfiler().start(PROFILE_DAQP);
+      (void)solver_daqp->solve(HQPData);
+      getProfiler().stop(PROFILE_DAQP);
+
+      getProfiler().start(PROFILE_DAQP_COLD);
+      (void)solver_daqp_cold->solve(HQPData);
+      getProfiler().stop(PROFILE_DAQP_COLD);
+
+      getProfiler().start(PROFILE_DAQP_REUSE);
+      (void)solver_daqp_reuse->solve(HQPData);
+      getProfiler().stop(PROFILE_DAQP_REUSE);
+
+      getProfiler().start(PROFILE_DAQP_REUSE_COLD);
+      (void)solver_daqp_reuse_cold->solve(HQPData);
+      getProfiler().stop(PROFILE_DAQP_REUSE_COLD);
+#endif
 
 #ifdef TSID_WITH_PROXSUITE
       getProfiler().start(PROFILE_PROXQP);
@@ -441,6 +531,15 @@ BOOST_AUTO_TEST_CASE(test_eiquadprog_classic_vs_rt_vs_fast_vs_proxqp) {
     getStatistics().store("active inequalities",
                           (double)output_rt.activeSet.size());
     getStatistics().store("solver iterations", output_rt.iterations);
+#ifdef TSID_WITH_DAQP
+    getStatistics().store("DAQP solver iterations", output_daqp.iterations);
+    getStatistics().store("DAQP cold solver iterations",
+                          output_daqp_cold.iterations);
+    getStatistics().store("DAQP reuse solver iterations",
+                          output_daqp_reuse.iterations);
+    getStatistics().store("DAQP reuse cold solver iterations",
+                          output_daqp_reuse_cold.iterations);
+#endif
 
     BOOST_REQUIRE_MESSAGE(
         output.status == output_rt.status,
@@ -451,6 +550,29 @@ BOOST_AUTO_TEST_CASE(test_eiquadprog_classic_vs_rt_vs_fast_vs_proxqp) {
         "Status " + SolverHQPBase::HQP_status_string[output.status] +
             " Status FAST " +
             SolverHQPBase::HQP_status_string[output_fast.status]);
+
+#ifdef TSID_WITH_DAQP
+    BOOST_REQUIRE_MESSAGE(
+        output.status == output_daqp.status,
+        "Status " + SolverHQPBase::HQP_status_string[output.status] +
+            " Status DAQP " +
+            SolverHQPBase::HQP_status_string[output_daqp.status]);
+    BOOST_REQUIRE_MESSAGE(
+        output.status == output_daqp_cold.status,
+        "Status " + SolverHQPBase::HQP_status_string[output.status] +
+            " Status DAQP cold " +
+            SolverHQPBase::HQP_status_string[output_daqp_cold.status]);
+    BOOST_REQUIRE_MESSAGE(
+        output.status == output_daqp_reuse.status,
+        "Status " + SolverHQPBase::HQP_status_string[output.status] +
+            " Status DAQP reuse " +
+            SolverHQPBase::HQP_status_string[output_daqp_reuse.status]);
+    BOOST_REQUIRE_MESSAGE(
+        output.status == output_daqp_reuse_cold.status,
+        "Status " + SolverHQPBase::HQP_status_string[output.status] +
+            " Status DAQP reuse cold " +
+            SolverHQPBase::HQP_status_string[output_daqp_reuse_cold.status]);
+#endif
 
 #ifdef TSID_WITH_PROXSUITE
     BOOST_REQUIRE_MESSAGE(
@@ -493,6 +615,24 @@ BOOST_AUTO_TEST_CASE(test_eiquadprog_classic_vs_rt_vs_fast_vs_proxqp) {
           //                        "\nSol FAST
           //                        "+toString(output_fast.x.transpose())+
           "\nDiff FAST: " + toString((output_rt.x - output_fast.x).norm()));
+
+#ifdef TSID_WITH_DAQP
+      BOOST_CHECK_MESSAGE(
+          output.x.isApprox(output_daqp.x, 1e-5),
+          "\nDiff DAQP: " + toString((output.x - output_daqp.x).norm()));
+      BOOST_CHECK_MESSAGE(
+          output.x.isApprox(output_daqp_cold.x, 1e-5),
+          "\nDiff DAQP cold: " +
+              toString((output.x - output_daqp_cold.x).norm()));
+      BOOST_CHECK_MESSAGE(
+          output.x.isApprox(output_daqp_reuse.x, 1e-5),
+          "\nDiff DAQP reuse: " +
+              toString((output.x - output_daqp_reuse.x).norm()));
+      BOOST_CHECK_MESSAGE(
+          output.x.isApprox(output_daqp_reuse_cold.x, 1e-5),
+          "\nDiff DAQP reuse cold: " +
+              toString((output.x - output_daqp_reuse_cold.x).norm()));
+#endif
 
 #ifdef TSID_WITH_PROXSUITE
       BOOST_CHECK_MESSAGE(

--- a/tests/hqp_solvers.cpp
+++ b/tests/hqp_solvers.cpp
@@ -88,8 +88,7 @@ BOOST_AUTO_TEST_CASE(test_daqp_multilevel_hierarchy) {
   BOOST_REQUIRE_EQUAL(warmOutput.status, HQP_STATUS_OPTIMAL);
   BOOST_CHECK(warmOutput.x.isApprox(expected, 1e-5));
 
-  static_cast<SolverHQPDAQP*>(solver.get())
-      ->setAssumeMatricesUnchanged(true);
+  static_cast<SolverHQPDAQP*>(solver.get())->setAssumeMatricesUnchanged(true);
   secondLevel->vector()[1] = 4.;
   const HQPOutput& updatedOutput = solver->solve(data);
   BOOST_REQUIRE_EQUAL(updatedOutput.status, HQP_STATUS_OPTIMAL);
@@ -105,8 +104,8 @@ BOOST_AUTO_TEST_CASE(test_daqp_weighted_level) {
   SolverHQPDAQP solver("daqp");
   HQPData data(2);
   Matrix A = Matrix::Ones(1, 1);
-  auto zero = std::make_shared<ConstraintEquality>(
-      "zero", 2. * A, Vector::Zero(1));
+  auto zero =
+      std::make_shared<ConstraintEquality>("zero", 2. * A, Vector::Zero(1));
   auto two =
       std::make_shared<ConstraintEquality>("two", A, Vector::Constant(1, 2.));
   auto hardRange = std::make_shared<ConstraintInequality>(
@@ -620,10 +619,9 @@ BOOST_AUTO_TEST_CASE(test_eiquadprog_classic_vs_rt_vs_fast_vs_proxqp) {
       BOOST_CHECK_MESSAGE(
           output.x.isApprox(output_daqp.x, 1e-5),
           "\nDiff DAQP: " + toString((output.x - output_daqp.x).norm()));
-      BOOST_CHECK_MESSAGE(
-          output.x.isApprox(output_daqp_cold.x, 1e-5),
-          "\nDiff DAQP cold: " +
-              toString((output.x - output_daqp_cold.x).norm()));
+      BOOST_CHECK_MESSAGE(output.x.isApprox(output_daqp_cold.x, 1e-5),
+                          "\nDiff DAQP cold: " +
+                              toString((output.x - output_daqp_cold.x).norm()));
       BOOST_CHECK_MESSAGE(
           output.x.isApprox(output_daqp_reuse.x, 1e-5),
           "\nDiff DAQP reuse: " +


### PR DESCRIPTION
## Summary

This PR adds DAQP as an optional TSID HQP solver (see #301 for some more context.)
Specifically this PR:

- Adds DAQP solver integration, factory support, bindings, and tests.
- Supports arbitrary hierarchical QPs through DAQP's native hierarchy handling.
- Uses a conventional dense QP for the common two-level case:
    - level 0: hard constraints
    - level 1: weighted equality tasks

- Reuses the DAQP workspace across solves, including primal/dual warm-start state.
- Adds SolverHQPDAQP::setAssumeMatricesUnchanged(bool) for explicit factorization and transformed-matrix reuse when the caller knows matrices, weights, hierarchy structure, and hard bounds are unchanged. _Keeps full numerical refreshes as the default behavior_.

## Benchmark

Measured on TSID's existing 60-variable HQP solver workload with 5,100 solves per solver:

| Solver | Avg ms | p95 ms | Max ms |
| :--- | :---: | :---: | :---: |
| DAQP full refresh, warm | 0.150 | 0.163 | 0.356 |
| DAQP full refresh, cold | 0.189 | 0.214 | 0.365 |
| DAQP reuse, warm | 0.050 | 0.064 | 0.344 |
| DAQP reuse, cold | 0.089 | 0.133 | 0.334 |
| EiQuadProg | 0.222 | 0.237 | 0.639 |
| EiQuadProg Fast | 0.209 | 0.223 | 0.852 |
| EiQuadProg RT | 0.206 | 0.219 | 0.523 |
| ProxQP | 0.416 | 0.523 | 1.616 |


Reuse performs a full update after each perturbation and enables reuse only for the following unchanged solves.

## Validation

- DAQP multilevel, weighted two-level, warm-start, factor reuse, and solution-agreement checks pass.


## Installation
To build the optional DAQP solver, install [DAQP](https://github.com/darnstrom/daqp) and add `-DBUILD_WITH_DAQP=ON` to the CMake command.